### PR TITLE
fix: 重写气泡系统，修复定位/重叠/图片重复/打包等问题

### DIFF
--- a/electron/ipc/desktop.ts
+++ b/electron/ipc/desktop.ts
@@ -6,6 +6,10 @@
 import { BrowserWindow, desktopCapturer, screen } from 'electron'
 import { bridgeClient } from '../main'
 import { getUserName } from '../database/schema'
+import {
+  getActiveWindow as loadActiveWindow,
+  safeGetActiveWindow as safeLoadActiveWindow,
+} from '../utils/activeWinLoader'
 import type {
   DesktopWindowInfo,
   DesktopCaptureRequestPayload,
@@ -15,22 +19,12 @@ import type {
   DesktopToolDeclaration,
 } from '../protocol/types'
 
-// active-win 是纯 ESM 包，动态导入
-let activeWinFn: (() => Promise<any>) | null = null
 async function getActiveWin(): Promise<any> {
-  if (!activeWinFn) {
-    const mod = await import('active-win')
-    activeWinFn = mod.default
-  }
-  return activeWinFn()
+  return await loadActiveWindow()
 }
 
 async function safeGetActiveWin(): Promise<any | null> {
-  try {
-    return await getActiveWin()
-  } catch {
-    return null
-  }
+  return await safeLoadActiveWindow()
 }
 
 function normalizeToken(value: unknown): string {

--- a/electron/ipc/shortcut.ts
+++ b/electron/ipc/shortcut.ts
@@ -1,4 +1,5 @@
-import { ipcMain, globalShortcut, BrowserWindow } from 'electron'
+import { ipcMain, globalShortcut } from 'electron'
+import { getMainWindow } from '../windows/mainWindow'
 
 let currentShortcut: string | null = null
 let isRecording = false
@@ -61,8 +62,8 @@ ipcMain.handle('shortcut:isRegistered', async (_event, accelerator: string) => {
  * 处理快捷键按下（切换模式）
  */
 function handleShortcutPressed() {
-  const mainWindow = BrowserWindow.getAllWindows().find(win => !win.isDestroyed())
-  if (!mainWindow) return
+  const mainWindow = getMainWindow()
+  if (!mainWindow || mainWindow.isDestroyed()) return
 
   if (!isRecording) {
     // 开始录音

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -143,7 +143,6 @@ export function initBridgeClient() {
   })
 
   bridgeClient.on('perform:show', (payload) => {
-    console.log('[主进程] 收到表演指令:', payload)
     BrowserWindow.getAllWindows().forEach(win => {
       win.webContents.send('perform:show', payload)
     })

--- a/electron/utils/activeWinLoader.ts
+++ b/electron/utils/activeWinLoader.ts
@@ -1,0 +1,90 @@
+/**
+ * 直接加载 active-win 的 native binding，绕过 @mapbox/node-pre-gyp 解析链。
+ * 打包后 ASAR 中不含 @mapbox/node-pre-gyp 及其大量传递依赖，
+ * 导致 active-win/lib/windows-binding.js 静默降级为空函数。
+ *
+ * 这里复制了 node-pre-gyp 对 active-win 的路径计算逻辑，
+ * 直接 require() 解包后的 .node 文件。
+ */
+
+import { createRequire } from 'module'
+import { app } from 'electron'
+import path from 'path'
+import fs from 'fs'
+
+const nodeRequire = createRequire(import.meta.url)
+
+let cachedBinding: any = null
+let loadAttempted = false
+
+function findBindingPath(): string | null {
+  const platform = process.platform
+  const arch = process.arch
+  // active-win 的 package.json binary.napi_versions = [3, 6]，实际预构建用 napi-6
+  const dir = `napi-6-${platform}-unknown-${arch}`
+  const fileName = 'node-active-win.node'
+
+  const appPath = app.getAppPath()
+  // asarUnpack: ["**/*.node"] 将 .node 文件提取到 app.asar.unpacked/
+  const unpackedBase = appPath.replace('app.asar', 'app.asar.unpacked')
+
+  const candidates = [
+    // 打包后（ASAR 解包目录）
+    path.join(unpackedBase, 'node_modules', 'active-win', 'lib', 'binding', dir, fileName),
+    // 开发模式（项目根目录下）
+    path.join(appPath, 'node_modules', 'active-win', 'lib', 'binding', dir, fileName),
+  ]
+
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) return p
+    } catch {
+      // ASAR 内 existsSync 可能抛异常，忽略
+    }
+  }
+  return null
+}
+
+function loadBinding(): any {
+  if (loadAttempted) return cachedBinding
+  loadAttempted = true
+
+  const bindingPath = findBindingPath()
+  if (!bindingPath) {
+    console.warn('[active-win] native binding 未找到，窗口检测不可用')
+    return null
+  }
+
+  try {
+    cachedBinding = nodeRequire(bindingPath)
+    console.log('[active-win] native binding 加载成功:', bindingPath)
+  } catch (err) {
+    console.warn('[active-win] native binding 加载失败:', err)
+  }
+
+  return cachedBinding
+}
+
+/**
+ * 获取当前活跃窗口信息，返回值与 active-win 包一致
+ */
+export async function getActiveWindow(): Promise<any | undefined> {
+  const binding = loadBinding()
+  if (!binding?.getActiveWindow) return undefined
+  try {
+    return binding.getActiveWindow()
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * 安全版本：出错时返回 null
+ */
+export async function safeGetActiveWindow(): Promise<any | null> {
+  try {
+    return (await getActiveWindow()) ?? null
+  } catch {
+    return null
+  }
+}

--- a/electron/utils/gameMode.ts
+++ b/electron/utils/gameMode.ts
@@ -2,6 +2,7 @@ import { screen } from 'electron'
 import { getMainWindow, hideMainWindow, showMainWindow } from '../windows/mainWindow'
 import { createRequire } from 'module'
 import { getPlatformCapabilities } from './platformCapabilities'
+import { safeGetActiveWindow as safeGetActiveWin } from './activeWinLoader'
 
 const require = createRequire(import.meta.url)
 const platformCapabilities = getPlatformCapabilities()
@@ -10,7 +11,6 @@ let isGameModeEnabled = false
 let checkInterval: NodeJS.Timeout | null = null
 let isHiddenByGameMode = false
 let windowManager: any = null
-let activeWinFn: (() => Promise<any>) | null = null
 let hasLoggedUnsupportedReason = false
 
 const MESSENGER_OVERLAY_TITLES = new Set([
@@ -78,21 +78,7 @@ function isLikelyMessengerScreenshotOverlay(
   return nearOrigin && nearScreenSize
 }
 
-async function getActiveWin(): Promise<any> {
-  if (!activeWinFn) {
-    const mod = await import('active-win')
-    activeWinFn = mod.default
-  }
-  return activeWinFn()
-}
-
-async function safeGetActiveWin(): Promise<any | null> {
-  try {
-    return await getActiveWin()
-  } catch {
-    return null
-  }
-}
+// active-win 由 activeWinLoader 统一加载
 
 function shouldIgnoreTransientFullscreen(title: string): boolean {
   const lowerTitle = normalizeToken(title)

--- a/src/utils/bubbleContent.ts
+++ b/src/utils/bubbleContent.ts
@@ -26,6 +26,30 @@ export function resolvePerformMediaSource(
   return resolveResourceSource(element, resourceConfig)
 }
 
+// 合并连续互补的 image 元素（服务端常将同一张图片拆成 inline + url/rid 两个元素发送）
+function mergeConsecutiveImages(sequence: BubblePerformElement[]): BubblePerformElement[] {
+  const result: BubblePerformElement[] = []
+  for (const el of sequence) {
+    const prev = result[result.length - 1]
+    if (
+      String(el?.type || '') === 'image' &&
+      prev && String(prev.type) === 'image'
+    ) {
+      const prevHasInline = Boolean(typeof prev.inline === 'string' && prev.inline.trim())
+      const elHasInline = Boolean(typeof el.inline === 'string' && el.inline?.trim())
+      // 一个有 inline 一个只有 url/rid → 同一张图的两种传输方式，合并
+      if (prevHasInline !== elHasInline) {
+        if (!prev.inline && el.inline) prev.inline = el.inline
+        if (!prev.url && el.url) prev.url = el.url
+        if (!prev.rid && el.rid) prev.rid = el.rid
+        continue
+      }
+    }
+    result.push({ ...el })
+  }
+  return result
+}
+
 export function splitPerformSequenceForBubble(
   sequence: BubblePerformElement[] | null | undefined,
   options: ResourceUrlConfig = {}
@@ -35,7 +59,7 @@ export function splitPerformSequenceForBubble(
   let position = 'center'
   let hasBubblePosition = false
 
-  for (const element of sequence || []) {
+  for (const element of mergeConsecutiveImages(sequence || [])) {
     const type = String(element?.type || '')
 
     if (!hasBubblePosition && (type === 'text' || type === 'image')) {

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -69,43 +69,29 @@
       </div>
     </Transition>
 
-    <!-- 旧气泡（上移淡出） -->
-    <Transition name="bubble-old">
+    <!-- 气泡栈：最多 3 个，从下往上堆叠，独立生命周期 -->
+    <TransitionGroup name="bubble" tag="div" class="bubble-stack-host">
       <div
-        v-if="oldBubble"
-        class="bubble bubble-old"
-        :style="{ ...oldBubbleStyle, '--bubble-offset-x': (oldBubble.offsetX ?? 0) + 'px' }"
-        @click.stop
-      >
-        <div class="bubble-content">
-          <div
-            v-for="item in oldBubble.items || []"
-            :key="item.id"
-            :class="['bubble-item', `bubble-item-${item.type}`]"
-          >
-            <div v-if="item.type === 'text'" class="bubble-text" v-html="renderBubbleMarkdown(item.renderedText)"></div>
-            <div v-else-if="item.type === 'image'" class="bubble-image">
-              <img :src="item.src" :alt="item.alt" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </Transition>
-
-    <!-- 文字气泡 -->
-    <Transition name="bubble">
-      <div
-        v-if="currentBubble"
+        v-for="(entry, i) in bubbleStack"
+        :key="entry.id"
+        :ref="(el) => setBubbleEl(entry.id, el as HTMLElement | null)"
         class="bubble"
-        ref="bubbleRef"
-        :style="{ ...bubbleStyle, '--bubble-offset-x': (currentBubble?.offsetX ?? 0) + 'px' }"
+        :class="bubbleTierClass(bubbleStack.length - 1 - i)"
+        :style="{
+          left: entry.styleLeft,
+          top: entry.styleTop,
+          '--bubble-offset-x': entry.offsetX + 'px',
+        }"
         @click.stop
-        @mouseenter="handleBubbleMouseEnter"
-        @mouseleave="handleBubbleMouseLeave"
+        @mouseenter="handleBubbleMouseEnter(entry)"
+        @mouseleave="handleBubbleMouseLeave(entry)"
       >
-        <div class="bubble-content" ref="bubbleContentRef">
+        <div
+          class="bubble-content"
+          :ref="(el) => setBubbleContentEl(entry.id, el as HTMLElement | null)"
+        >
           <div
-            v-for="item in currentBubble?.items || []"
+            v-for="item in entry.items"
             :key="item.id"
             :class="['bubble-item', `bubble-item-${item.type}`]"
           >
@@ -115,12 +101,12 @@
               v-html="renderBubbleMarkdown(item.renderedText)"
             ></div>
             <div v-else-if="item.type === 'image'" class="bubble-image">
-              <img :src="item.src" :alt="item.alt" @load="handleBubbleMediaLoad" />
+              <img :src="item.src" :alt="item.alt" @load="handleBubbleMediaLoad(entry.id)" />
             </div>
           </div>
         </div>
       </div>
-    </Transition>
+    </TransitionGroup>
 
     <!-- 模型状态提示 -->
     <Transition name="status-toast">
@@ -258,10 +244,18 @@ type BubbleImageItem = {
 
 type BubbleItem = BubbleTextItem | BubbleImageItem
 
-type BubbleState = {
-  position: string
+// 气泡栈条目，每个条目独立维护打字机状态和生命周期
+type BubbleEntry = {
+  id: string
   items: BubbleItem[]
-  offsetX?: number  // 随机水平偏移 px
+  offsetX: number        // 随机水平偏移 px（±30px）
+  typingIdx: number      // 下一个待打字的 item 下标
+  typingVer: number      // 递增取消令牌，与打字协程绑定
+  typingDone: boolean    // 所有 item 打字完成
+  hideTimerId: number | null
+  pinned: boolean        // 鼠标悬停，抑制自动隐藏
+  styleLeft: string
+  styleTop: string
 }
 
 const connectionStore = useConnectionStore()
@@ -281,27 +275,21 @@ const showMenu = ref(false)
 const menuStyle = ref({ left: '0px', top: '0px' })
 const themeColor = ref('rgba(100, 108, 255, 0.8)') // Default accent color
 let menuAutoCloseTimer: number | null = null
-const currentBubble = ref<BubbleState | null>(null)
-const oldBubble = ref<BubbleState | null>(null)
-const bubbleStyle = ref<{ left: string; top?: string; bottom?: string }>({ left: '0px', top: '0px' })
-const oldBubbleStyle = ref<{ left: string; top: string }>({ left: '0px', top: '0px' })
-let oldBubbleHideTimer: number | null = null
+// 气泡栈：index 0 = 最老（顶部），index length-1 = 最新（底部）
+const bubbleStack = ref<BubbleEntry[]>([])
+// DOM 元素引用（非响应式 Map，通过 :ref 回调维护）
+const bubbleElMap = new Map<string, HTMLElement>()
+const bubbleContentElMap = new Map<string, HTMLElement>()
+// 追踪上次收到表演包的时间，用于判断追加消息
 let lastPerformReceiveTime = 0
-const bubbleRef = ref<HTMLElement | null>(null)
-const bubbleContentRef = ref<HTMLElement | null>(null)
-let typewriterTimer: number | null = null
-let typewriterResolve: (() => void) | null = null
-let bubbleSequenceVersion = 0
-let bubbleTypingIndex = 0
-let isBubbleTyping = false
 
 const NORMAL_TYPEWRITER_INTERVAL = 50
 const TYPEWRITER_LAYOUT_UPDATE_INTERVAL_CHARS = 4
-const BUBBLE_MAX_WIDTH = 450
 const BUBBLE_EDGE_PADDING = 16
 const BUBBLE_VERTICAL_OFFSET = 200
-const OLD_BUBBLE_ABOVE_OFFSET = 130  // 旧气泡在当前气泡锚点上方的额外偏移 px
-const FOLLOW_UP_WINDOW_MS = 4000    // 视为同一轮回复的时间窗口 ms
+const BUBBLE_GAP = 10          // 堆叠气泡间距 px
+const BUBBLE_STACK_MAX = 3     // 最大气泡数量
+const FOLLOW_UP_WINDOW_MS = 4000  // 追加消息时间窗口 ms
 const showInput = ref(false)
 const inputRef = ref<HTMLInputElement | null>(null)
 const inputStyle = ref({ left: '0px', top: '0px' })
@@ -335,8 +323,6 @@ function generateMessageId(prefix = 'msg'): string {
 let audioRecorder: AudioRecorder | null = null
 let recordingTimer: NodeJS.Timeout | null = null
 let isStoppingRecording = false
-let bubbleHoverTimer: NodeJS.Timeout | null = null
-const isBubbleHovered = ref(false)
 let modelPositionX = window.innerWidth / 2
 let modelPositionY = window.innerHeight / 2
 let alwaysOnTopBeforeImport: boolean | null = null
@@ -424,17 +410,10 @@ watch(hasModel, async (value) => {
   }
 })
 
-// 监听气泡关闭，重置打字机
-watch(currentBubble, (val) => {
-  if (val) {
-    scheduleBubbleLayoutUpdate()
-    return
-  }
-
-  if (!val) {
-    resetBubbleTypingState()
-  }
-})
+// 气泡栈变化时重新计算堆叠位置
+watch(bubbleStack, () => {
+  nextTick(() => updateStackPositions())
+}, { deep: false })
 
 // 配置 marked（与 History.vue 相同）
 marked.setOptions({
@@ -509,37 +488,50 @@ function renderBubbleMarkdown(text: string): string {
   }
 }
 
+// ─── 气泡栈辅助函数 ───────────────────────────────────────────────────────────
+
+function setBubbleEl(id: string, el: HTMLElement | null) {
+  if (el) {
+    bubbleElMap.set(id, el)
+  } else {
+    bubbleElMap.delete(id)
+  }
+}
+
+function setBubbleContentEl(id: string, el: HTMLElement | null) {
+  if (el) {
+    bubbleContentElMap.set(id, el)
+  } else {
+    bubbleContentElMap.delete(id)
+  }
+}
+
+// 返回气泡层级 CSS 类名（0=最新/底部，1=上一层，2=更上层）
+function bubbleTierClass(tier: number): string {
+  if (tier === 0) return 'bubble-tier-0'
+  if (tier === 1) return 'bubble-tier-1'
+  return 'bubble-tier-2'
+}
+
 function scheduleBubbleLayoutUpdate() {
   nextTick(() => {
-    updateBubblePosition()
-    if (bubbleContentRef.value) {
-      bubbleContentRef.value.scrollTop = bubbleContentRef.value.scrollHeight
+    updateStackPositions()
+    // 滚动最新气泡内容到底部
+    const stack = bubbleStack.value
+    if (stack.length > 0) {
+      const el = bubbleContentElMap.get(stack[stack.length - 1].id)
+      if (el) el.scrollTop = el.scrollHeight
     }
   })
 }
 
-function handleBubbleMediaLoad() {
-  scheduleBubbleLayoutUpdate()
-}
-
-function clearTypewriterTimer() {
-  if (typewriterTimer !== null) {
-    clearInterval(typewriterTimer)
-    typewriterTimer = null
-  }
-
-  if (typewriterResolve) {
-    const resolve = typewriterResolve
-    typewriterResolve = null
-    resolve()
-  }
-}
-
-function resetBubbleTypingState() {
-  clearTypewriterTimer()
-  bubbleSequenceVersion += 1
-  bubbleTypingIndex = 0
-  isBubbleTyping = false
+function handleBubbleMediaLoad(entryId: string) {
+  // 图片加载完成后重新计算堆叠位置
+  nextTick(() => {
+    updateStackPositions()
+    const el = bubbleContentElMap.get(entryId)
+    if (el) el.scrollTop = el.scrollHeight
+  })
 }
 
 function createBubbleItems(items: BubbleRenderableItem[]): BubbleItem[] {
@@ -547,254 +539,202 @@ function createBubbleItems(items: BubbleRenderableItem[]): BubbleItem[] {
     if (item.type === 'text') {
       return {
         id: generateMessageId('bubble_text'),
-        type: 'text',
+        type: 'text' as const,
         fullText: item.text,
         renderedText: '',
       }
     }
-
     return {
       id: generateMessageId('bubble_image'),
-      type: 'image',
+      type: 'image' as const,
       src: item.src,
       alt: item.alt,
     }
   })
 }
 
-function getCurrentBubbleAutoHideDelay(): number {
-  if (!currentBubble.value) {
-    return 5000
+// ─── 堆叠定位 ────────────────────────────────────────────────────────────────
+
+function updateStackPositions() {
+  const stack = bubbleStack.value
+  if (!stack.length) return
+
+  const viewportWidth = window.innerWidth
+  const anchorX = modelPositionX
+  // 锚点底边：模型中心往上 BUBBLE_VERTICAL_OFFSET px
+  let currentBottom = modelPositionY - BUBBLE_VERTICAL_OFFSET
+
+  // 从最新（底部）往最老（顶部）依次计算
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const entry = stack[i]
+    const el = bubbleElMap.get(entry.id)
+    const elH = el?.offsetHeight ?? 80
+    const elW = el?.offsetWidth ?? 300
+    const halfW = elW / 2
+    const minLeft = BUBBLE_EDGE_PADDING + halfW
+    const maxLeft = viewportWidth - BUBBLE_EDGE_PADDING - halfW
+    const rawLeft = anchorX + entry.offsetX
+    const clampedLeft = Math.min(Math.max(rawLeft, minLeft), maxLeft)
+
+    const top = currentBottom - elH
+    const clampedTop = Math.max(BUBBLE_EDGE_PADDING, top)
+
+    entry.styleLeft = `${clampedLeft}px`
+    entry.styleTop = `${clampedTop}px`
+
+    // 下一个气泡要放在这个气泡上方（留 GAP）
+    currentBottom = clampedTop - BUBBLE_GAP
+  }
+}
+
+// ─── 独立打字机 ───────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function typeItemChars(item: BubbleTextItem, entry: BubbleEntry, localVer: number) {
+  let idx = item.renderedText.length
+  let sinceLayout = 0
+
+  while (idx < item.fullText.length) {
+    if (entry.typingVer !== localVer) return
+    item.renderedText += item.fullText.charAt(idx)
+    idx++
+    sinceLayout++
+    if (sinceLayout >= TYPEWRITER_LAYOUT_UPDATE_INTERVAL_CHARS || idx >= item.fullText.length) {
+      sinceLayout = 0
+      scheduleBubbleLayoutUpdate()
+    }
+    await sleep(NORMAL_TYPEWRITER_INTERVAL)
+  }
+}
+
+async function runEntryTypewriter(entry: BubbleEntry) {
+  const localVer = entry.typingVer
+
+  while (entry.typingIdx < entry.items.length) {
+    if (entry.typingVer !== localVer) return
+    const item = entry.items[entry.typingIdx]
+    entry.typingIdx++
+
+    if (item.type === 'text') {
+      await typeItemChars(item as BubbleTextItem, entry, localVer)
+    } else {
+      scheduleBubbleLayoutUpdate()
+    }
+    if (entry.typingVer !== localVer) return
   }
 
-  return computeBubbleAutoHideDelay(
-    currentBubble.value.items.map((item) => {
-      if (item.type === 'text') {
-        return { type: 'text', text: item.fullText }
-      }
+  // 所有 item 打字完成
+  if (entry.typingVer === localVer) {
+    entry.typingDone = true
+    startEntryHideTimer(entry)
+  }
+}
 
-      return { type: 'image', src: item.src, alt: item.alt }
+// 强制冻结条目（将所有文本跳到最终状态，取消打字机）
+function freezeEntry(entry: BubbleEntry) {
+  entry.typingVer++  // 取消正在运行的打字协程
+  for (const item of entry.items) {
+    if (item.type === 'text') {
+      (item as BubbleTextItem).renderedText = (item as BubbleTextItem).fullText
+    }
+  }
+  entry.typingDone = true
+}
+
+// ─── 自动隐藏 ─────────────────────────────────────────────────────────────────
+
+function computeEntryAutoHideDelay(entry: BubbleEntry): number {
+  return computeBubbleAutoHideDelay(
+    entry.items.map((item) => {
+      if (item.type === 'text') return { type: 'text' as const, text: (item as BubbleTextItem).fullText }
+      return { type: 'image' as const, src: (item as BubbleImageItem).src, alt: (item as BubbleImageItem).alt }
     })
   )
 }
 
-function runTypewriterForBubbleItem(
-  item: BubbleTextItem,
-  version: number,
-  intervalMs: number = NORMAL_TYPEWRITER_INTERVAL
-): Promise<void> {
-  clearTypewriterTimer()
-
-  let index = 0
-  let typedSinceLastLayoutUpdate = 0
-
-  if (item.fullText.startsWith(item.renderedText) && item.renderedText.length > 0) {
-    index = item.renderedText.length
-  } else {
-    item.renderedText = ''
-  }
-
-  if (index >= item.fullText.length) {
-    item.renderedText = item.fullText
-    scheduleBubbleLayoutUpdate()
-    return Promise.resolve()
-  }
-
-  return new Promise((resolve) => {
-    typewriterResolve = resolve
-
-    typewriterTimer = window.setInterval(() => {
-      if (version !== bubbleSequenceVersion || !currentBubble.value) {
-        clearTypewriterTimer()
-        return
-      }
-
-      if (index >= item.fullText.length) {
-        clearTypewriterTimer()
-        return
-      }
-
-      item.renderedText += item.fullText.charAt(index)
-      index += 1
-      typedSinceLastLayoutUpdate += 1
-
-      if (
-        typedSinceLastLayoutUpdate >= TYPEWRITER_LAYOUT_UPDATE_INTERVAL_CHARS ||
-        index >= item.fullText.length
-      ) {
-        typedSinceLastLayoutUpdate = 0
-        scheduleBubbleLayoutUpdate()
-      }
-
-      if (index >= item.fullText.length) {
-        clearTypewriterTimer()
-      }
-    }, intervalMs)
-  })
-}
-
-async function ensureBubbleTyping(version: number = bubbleSequenceVersion) {
-  if (isBubbleTyping || version !== bubbleSequenceVersion || !currentBubble.value) {
-    return
-  }
-
-  isBubbleTyping = true
-
-  try {
-    while (currentBubble.value && version === bubbleSequenceVersion) {
-      if (bubbleTypingIndex >= currentBubble.value.items.length) {
-        break
-      }
-
-      const nextItem = currentBubble.value.items[bubbleTypingIndex]
-      bubbleTypingIndex += 1
-
-      if (nextItem.type === 'text') {
-        await runTypewriterForBubbleItem(nextItem, version)
-      } else {
-        scheduleBubbleLayoutUpdate()
-      }
-    }
-  } finally {
-    isBubbleTyping = false
-  }
-}
-
-function updateOldBubblePosition() {
-  if (!oldBubble.value) return
-  const offsetX = oldBubble.value.offsetX ?? 0
-  const viewportWidth = window.innerWidth
-  const halfWidth = 180  // 旧气泡宽度估算
-  const minLeft = BUBBLE_EDGE_PADDING + halfWidth
-  const maxLeft = viewportWidth - BUBBLE_EDGE_PADDING - halfWidth
-  const rawLeft = modelPositionX + offsetX
-  const clampedLeft = Math.min(Math.max(rawLeft, minLeft), maxLeft)
-  oldBubbleStyle.value = {
-    left: `${clampedLeft}px`,
-    top: `${modelPositionY - BUBBLE_VERTICAL_OFFSET - OLD_BUBBLE_ABOVE_OFFSET}px`,
-  }
-}
-
-function startOldBubbleHideTimer() {
-  if (oldBubbleHideTimer) clearTimeout(oldBubbleHideTimer)
-  oldBubbleHideTimer = window.setTimeout(() => {
-    oldBubble.value = null
-    oldBubbleHideTimer = null
-  }, 8000)
-}
-
-function clearOldBubble() {
-  if (oldBubbleHideTimer) {
-    clearTimeout(oldBubbleHideTimer)
-    oldBubbleHideTimer = null
-  }
-  oldBubble.value = null
-}
-
-function showPerformBubble(
-  bubbleItems: BubbleRenderableItem[],
-  position: string,
-  interrupt: boolean,
-  isFollowUp: boolean = false
-) {
-  if (!bubbleItems.length) {
-    return
-  }
-
-  const runtimeItems = createBubbleItems(bubbleItems)
-
-  if (isFollowUp && currentBubble.value) {
-    // 多气泡模式：当前气泡上移成旧气泡，新气泡从下方出现
-    const offsetX = Math.round((Math.random() - 0.5) * 60)  // ±30px
-    oldBubble.value = { ...currentBubble.value, offsetX }
-    updateOldBubblePosition()
-    startOldBubbleHideTimer()
-    resetBubbleTypingState()
-    const newOffsetX = Math.round((Math.random() - 0.5) * 30)  // ±15px
-    currentBubble.value = { position, items: runtimeItems, offsetX: newOffsetX }
-  } else if (interrupt || !currentBubble.value) {
-    clearOldBubble()
-    resetBubbleTypingState()
-    currentBubble.value = {
-      position,
-      items: runtimeItems,
-      offsetX: 0,
-    }
-  } else {
-    currentBubble.value.position = currentBubble.value.position || position
-    currentBubble.value.items.push(...runtimeItems)
-  }
-
-  scheduleBubbleLayoutUpdate()
-  startBubbleHideTimer(getCurrentBubbleAutoHideDelay())
-  void ensureBubbleTyping()
-}
-
-// 气泡鼠标进入
-function handleBubbleMouseEnter() {
-  isBubbleHovered.value = true
-  // 清除自动隐藏定时器
-  if (bubbleHoverTimer) {
-    clearTimeout(bubbleHoverTimer)
-    bubbleHoverTimer = null
-  }
-}
-
-// 气泡鼠标离开
-function handleBubbleMouseLeave() {
-  isBubbleHovered.value = false
-  // 鼠标离开后 3 秒自动隐藏
-  startBubbleHideTimer(3000)
-}
-
-// 启动气泡自动隐藏定时器
-function startBubbleHideTimer(delay: number) {
-  // 清除旧的定时器
-  if (bubbleHoverTimer) {
-    clearTimeout(bubbleHoverTimer)
-  }
-  // 设置新的定时器
-  bubbleHoverTimer = setTimeout(() => {
-    if (!isBubbleHovered.value) {
-      currentBubble.value = null
-    }
+function startEntryHideTimer(entry: BubbleEntry) {
+  if (entry.pinned) return  // 悬停时不启动
+  if (entry.hideTimerId !== null) clearTimeout(entry.hideTimerId)
+  const delay = computeEntryAutoHideDelay(entry)
+  entry.hideTimerId = window.setTimeout(() => {
+    removeEntry(entry.id)
   }, delay)
 }
 
-function updateBubblePosition() {
-  if (!currentBubble.value) {
-    return
+function removeEntry(id: string) {
+  const idx = bubbleStack.value.findIndex((e) => e.id === id)
+  if (idx === -1) return
+  const entry = bubbleStack.value[idx]
+  if (entry.hideTimerId !== null) clearTimeout(entry.hideTimerId)
+  entry.typingVer++  // 取消打字协程
+  bubbleStack.value.splice(idx, 1)
+}
+
+function clearAllBubbles() {
+  for (const entry of bubbleStack.value) {
+    if (entry.hideTimerId !== null) clearTimeout(entry.hideTimerId)
+    entry.typingVer++
+  }
+  bubbleStack.value = []
+}
+
+// ─── 鼠标交互 ─────────────────────────────────────────────────────────────────
+
+function handleBubbleMouseEnter(entry: BubbleEntry) {
+  entry.pinned = true
+  if (entry.hideTimerId !== null) {
+    clearTimeout(entry.hideTimerId)
+    entry.hideTimerId = null
+  }
+}
+
+function handleBubbleMouseLeave(entry: BubbleEntry) {
+  entry.pinned = false
+  if (entry.typingDone) {
+    // 离开后 3s 隐藏
+    entry.hideTimerId = window.setTimeout(() => removeEntry(entry.id), 3000)
+  }
+}
+
+// ─── 主入口：推入新气泡 ───────────────────────────────────────────────────────
+
+function pushBubble(bubbleItems: BubbleRenderableItem[], _position: string, interrupt: boolean) {
+  if (!bubbleItems.length) return
+
+  if (interrupt) {
+    clearAllBubbles()
   }
 
-  const viewportWidth = window.innerWidth
-  const viewportHeight = window.innerHeight
-  const maxBubbleWidth = Math.max(0, Math.min(BUBBLE_MAX_WIDTH, viewportWidth - BUBBLE_EDGE_PADDING * 2))
-  const renderedWidth = bubbleRef.value?.offsetWidth ?? 0
-  const bubbleWidth = Math.max(0, Math.min(renderedWidth || maxBubbleWidth, maxBubbleWidth))
-  const bubbleHeight = bubbleRef.value?.offsetHeight ?? 0
-  const halfWidth = bubbleWidth / 2
-  const minLeft = BUBBLE_EDGE_PADDING + halfWidth
-  const maxLeft = viewportWidth - BUBBLE_EDGE_PADDING - halfWidth
-  const clampedLeft = maxLeft < minLeft
-    ? viewportWidth / 2
-    : Math.min(Math.max(modelPositionX, minLeft), maxLeft)
-
-  const anchorY = modelPositionY - BUBBLE_VERTICAL_OFFSET
-  const preferredTop = anchorY - bubbleHeight
-  const belowTop = anchorY + BUBBLE_EDGE_PADDING
-  const minTop = BUBBLE_EDGE_PADDING
-  const maxTop = Math.max(BUBBLE_EDGE_PADDING, viewportHeight - BUBBLE_EDGE_PADDING - bubbleHeight)
-
-  let resolvedTop = preferredTop
-  if (preferredTop < minTop && belowTop + bubbleHeight <= viewportHeight - BUBBLE_EDGE_PADDING) {
-    resolvedTop = belowTop
+  // 超过最大数量时驱逐最老的
+  if (bubbleStack.value.length >= BUBBLE_STACK_MAX) {
+    const oldest = bubbleStack.value[0]
+    freezeEntry(oldest)
+    bubbleStack.value.splice(0, 1)
   }
-  resolvedTop = Math.min(Math.max(resolvedTop, minTop), maxTop)
 
-  bubbleStyle.value = {
-    left: `${clampedLeft}px`,
-    top: `${resolvedTop}px`
+  const runtimeItems = createBubbleItems(bubbleItems)
+  const offsetX = Math.round((Math.random() - 0.5) * 50)  // ±25px 随机偏移
+  const entry: BubbleEntry = {
+    id: generateMessageId('bubble'),
+    items: runtimeItems,
+    offsetX,
+    typingIdx: 0,
+    typingVer: 0,
+    typingDone: false,
+    hideTimerId: null,
+    pinned: false,
+    styleLeft: '0px',
+    styleTop: '0px',
   }
+
+  bubbleStack.value.push(entry)
+  nextTick(() => {
+    updateStackPositions()
+    void runEntryTypewriter(entry)
+  })
 }
 
 // Create performance queue
@@ -802,7 +742,7 @@ const performQueue = new PerformanceQueue()
 
 // Register performance queue callbacks
 performQueue.onText((content, position, _duration) => {
-  showPerformBubble([{ type: 'text', text: content }], position, false)
+  pushBubble([{ type: 'text', text: content }], position, false)
 })
 
 performQueue.onMotion((group, index, priority) => {
@@ -835,7 +775,7 @@ performQueue.onImage((url, _duration) => {
     return
   }
 
-  showPerformBubble([{ type: 'image', src: resolvedSrc, alt: 'AstrBot message image' }], 'center', false)
+  pushBubble([{ type: 'image', src: resolvedSrc, alt: 'AstrBot message image' }], 'center', false)
 })
 
 performQueue.onVideo((url) => {
@@ -845,7 +785,7 @@ performQueue.onVideo((url) => {
 function interruptPerformance() {
   performQueue.interrupt()
 
-  resetBubbleTypingState()
+  clearAllBubbles()
 
   mediaPlayerRef.value?.stopAudio()
   mediaPlayerRef.value?.hideImage()
@@ -1041,14 +981,9 @@ function handleModelPositionChanged(position: { x: number; y: number }) {
 
 // 更新 UI 元素位置（跟随模型）
 function updateUIPositions() {
-  // 更新气泡位置（模型头顶上方 250px，避免遮挡模型）
-  if (currentBubble.value) {
-    updateBubblePosition()
-  }
-
-  // 同步旧气泡位置（跟随模型移动）
-  if (oldBubble.value) {
-    updateOldBubblePosition()
+  // 重新计算气泡栈位置
+  if (bubbleStack.value.length > 0) {
+    updateStackPositions()
   }
 
   // 更新状态提示位置（模型头顶上方 280px）
@@ -1601,10 +1536,11 @@ onMounted(async () => {
     console.log('收到表演指令:', payload)
 
     const now = Date.now()
-    // 同一轮回复（4s 窗口内）的追加消息不中断，做旧气泡上移效果
-    const isFollowUp = currentBubble.value !== null && (now - lastPerformReceiveTime) < FOLLOW_UP_WINDOW_MS
+    // 4s 窗口内的连续消息视为追加（不中断），超出则中断旧内容
+    const isFollowUp = bubbleStack.value.length > 0 && (now - lastPerformReceiveTime) < FOLLOW_UP_WINDOW_MS
     lastPerformReceiveTime = now
 
+    // interrupt=true 且不是追加时才中断旧表演
     const shouldInterrupt = payload.interrupt !== false && !isFollowUp
 
     if (shouldInterrupt) {
@@ -1623,7 +1559,7 @@ onMounted(async () => {
       )
 
       if (bubbleItems.length > 0) {
-        showPerformBubble(bubbleItems, position, shouldInterrupt, isFollowUp)
+        pushBubble(bubbleItems, position, shouldInterrupt)
       }
 
       if (remainingSequence.length > 0) {
@@ -1802,7 +1738,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('storage', handleStorageChange)
   window.removeEventListener('resize', updateUIPositions)
   clearRecordingTimer()
-  clearOldBubble()
+  clearAllBubbles()
 
   if (audioRecorder && isRecording.value) {
     audioRecorder.cancel()
@@ -1987,6 +1923,17 @@ onBeforeUnmount(() => {
   /* 恢复默认 transform (由 inline style 定义) */
 }
 
+/* 气泡栈宿主容器（零尺寸，仅作 TransitionGroup 挂载点） */
+.bubble-stack-host {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
 .bubble {
   position: absolute;
   background: rgba(26, 26, 26, 0.95);
@@ -2004,34 +1951,26 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  pointer-events: auto;
+  /* top/left 由 updateStackPositions 写入，transition 让位置变化平滑 */
   transform: translateX(calc(-50% + var(--bubble-offset-x, 0px)));
+  transition: top 0.3s ease-out, opacity 0.3s, transform 0.3s;
 }
 
-.bubble-old {
-  z-index: 99;
-  opacity: 0.6;
-  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.92);
-  filter: blur(0.4px);
-  pointer-events: auto;
-  cursor: default;
+/* 层级 1：上一个气泡，稍小稍暗 */
+.bubble-tier-1 {
+  opacity: 0.72;
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.95);
+  filter: blur(0.3px);
   max-height: min(40vh, calc(100vh - 32px));
 }
 
-.bubble-old-enter-active {
-  transition: opacity 0.35s ease, transform 0.35s ease-out;
-}
-
-.bubble-old-enter-from {
-  opacity: 0;
-  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.9) translateY(15px);
-}
-
-.bubble-old-leave-active {
-  transition: opacity 0.4s ease;
-}
-
-.bubble-old-leave-to {
-  opacity: 0;
+/* 层级 2：更上层，更小更暗 */
+.bubble-tier-2 {
+  opacity: 0.48;
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.88);
+  filter: blur(0.6px);
+  max-height: min(30vh, calc(100vh - 32px));
 }
 
 .bubble-content {
@@ -2431,13 +2370,31 @@ onBeforeUnmount(() => {
 
 
 
-.bubble-enter-active, .bubble-leave-active {
-  transition: opacity 0.3s, transform 0.3s;
+/* TransitionGroup 进入：从下方淡入 */
+.bubble-enter-active {
+  transition: opacity 0.3s ease-out, transform 0.35s ease-out;
 }
 
-.bubble-enter-from, .bubble-leave-to {
+.bubble-enter-from {
   opacity: 0;
-  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) translateY(20px) scale(0.9);
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) translateY(18px) scale(0.92);
+}
+
+/* TransitionGroup 离开：向上淡出 */
+.bubble-leave-active {
+  transition: opacity 0.28s ease-in, transform 0.28s ease-in;
+  /* 离开期间脱离流，避免影响其他气泡位置计算 */
+  position: absolute;
+}
+
+.bubble-leave-to {
+  opacity: 0;
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) translateY(-10px) scale(0.94);
+}
+
+/* 堆叠位置平移动画（新气泡插入时旧气泡上移） */
+.bubble-move {
+  transition: top 0.3s ease-out;
 }
 
 .input-enter-active, .input-leave-active {

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -731,9 +731,11 @@ function pushBubble(bubbleItems: BubbleRenderableItem[], _position: string, inte
   }
 
   bubbleStack.value.push(entry)
+  // push 后必须从数组取响应式代理，否则修改 renderedText 不触发重渲染
+  const reactiveEntry = bubbleStack.value[bubbleStack.value.length - 1]
   nextTick(() => {
     updateStackPositions()
-    void runEntryTypewriter(entry)
+    void runEntryTypewriter(reactiveEntry)
   })
 }
 
@@ -1943,7 +1945,7 @@ onBeforeUnmount(() => {
   font-size: 14px;
   width: max-content;
   max-width: min(450px, calc(100vw - 32px));
-  max-height: min(55vh, calc(100vh - 32px));
+  max-height: min(40vh, calc(100vh - 32px));
   backdrop-filter: blur(10px);
   box-shadow: var(--shadow-md);
   z-index: 100;
@@ -1962,7 +1964,7 @@ onBeforeUnmount(() => {
   opacity: 0.72;
   transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.95);
   filter: blur(0.3px);
-  max-height: min(40vh, calc(100vh - 32px));
+  max-height: min(32vh, calc(100vh - 32px));
 }
 
 /* 层级 2：更上层，更小更暗 */
@@ -1970,7 +1972,7 @@ onBeforeUnmount(() => {
   opacity: 0.48;
   transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.88);
   filter: blur(0.6px);
-  max-height: min(30vh, calc(100vh - 32px));
+  max-height: min(24vh, calc(100vh - 32px));
 }
 
 .bubble-content {

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -81,6 +81,7 @@
           left: entry.styleLeft,
           top: entry.styleTop,
           '--bubble-offset-x': entry.offsetX + 'px',
+          maxHeight: entry.styleMaxHeight || undefined,
         }"
         @click.stop
         @mouseenter="handleBubbleMouseEnter(entry)"
@@ -256,6 +257,7 @@ type BubbleEntry = {
   pinned: boolean        // 鼠标悬停，抑制自动隐藏
   styleLeft: string
   styleTop: string
+  styleMaxHeight: string // 动态 max-height，空字符串时使用 CSS 默认值
 }
 
 const connectionStore = useConnectionStore()
@@ -554,35 +556,83 @@ function createBubbleItems(items: BubbleRenderableItem[]): BubbleItem[] {
 
 // ─── 堆叠定位 ────────────────────────────────────────────────────────────────
 
+// 各层级 CSS max-height 对应的 vh 系数（须与 CSS 保持一致）
+const TIER_VH_FACTORS = [0.40, 0.32, 0.24]
+
+function getTierCSSMaxHeight(tier: number, vh: number): number {
+  const factor = TIER_VH_FACTORS[Math.min(tier, 2)]
+  return Math.min(factor * vh, vh - 32)
+}
+
 function updateStackPositions() {
   const stack = bubbleStack.value
   if (!stack.length) return
 
   const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
   const anchorX = modelPositionX
-  // 锚点底边：模型中心往上 BUBBLE_VERTICAL_OFFSET px
-  let currentBottom = modelPositionY - BUBBLE_VERTICAL_OFFSET
+  const usableHeight = viewportHeight - 2 * BUBBLE_EDGE_PADDING
 
-  // 从最新（底部）往最老（顶部）依次计算
-  for (let i = stack.length - 1; i >= 0; i--) {
-    const entry = stack[i]
+  // 测量每个气泡的自然高度（scrollHeight 不受 max-height 约束）
+  const data = stack.map((entry, i) => {
     const el = bubbleElMap.get(entry.id)
-    const elH = el?.offsetHeight ?? 80
-    const elW = el?.offsetWidth ?? 300
+    const contentEl = bubbleContentElMap.get(entry.id)
+    const tier = stack.length - 1 - i
+    const cssMaxH = getTierCSSMaxHeight(tier, viewportHeight)
+    const contentScrollH = contentEl?.scrollHeight ?? 56
+    // 自然高度 = 内容高度 + 气泡 padding，再不超过 CSS 层级上限
+    const naturalH = Math.min(contentScrollH + 24, cssMaxH)
+    return {
+      entry,
+      naturalHeight: naturalH,
+      width: el?.offsetWidth ?? 300,
+    }
+  })
+
+  const totalGaps = Math.max(0, stack.length - 1) * BUBBLE_GAP
+  const totalNaturalHeight = data.reduce((s, d) => s + d.naturalHeight, 0) + totalGaps
+  const idealAnchor = modelPositionY - BUBBLE_VERTICAL_OFFSET
+
+  let anchorBottom: number
+  let finalHeights: number[]
+
+  if (totalNaturalHeight <= idealAnchor - BUBBLE_EDGE_PADDING) {
+    // 完全放得下 — 理想位置
+    anchorBottom = idealAnchor
+    finalHeights = data.map(d => d.naturalHeight)
+    for (const d of data) d.entry.styleMaxHeight = ''
+  } else if (totalNaturalHeight <= usableHeight) {
+    // 放不下锚点上方但视口内放得下 — 整体下移
+    anchorBottom = BUBBLE_EDGE_PADDING + totalNaturalHeight
+    finalHeights = data.map(d => d.naturalHeight)
+    for (const d of data) d.entry.styleMaxHeight = ''
+  } else {
+    // 视口也放不下 — 按比例缩小
+    anchorBottom = viewportHeight - BUBBLE_EDGE_PADDING
+    const usableForBubbles = Math.max(0, usableHeight - totalGaps)
+    const totalNatural = data.reduce((s, d) => s + d.naturalHeight, 0)
+    const scale = totalNatural > 0 ? usableForBubbles / totalNatural : 1
+    const MIN_BUBBLE_H = 60
+    finalHeights = data.map(d => Math.max(MIN_BUBBLE_H, Math.floor(d.naturalHeight * scale)))
+    for (let i = 0; i < data.length; i++) {
+      data[i].entry.styleMaxHeight = `${finalHeights[i]}px`
+    }
+  }
+
+  // 从最新（底部）往最老（顶部）依次放置，绝不重叠
+  let currentBottom = anchorBottom
+  for (let i = data.length - 1; i >= 0; i--) {
+    const { entry, width: elW } = data[i]
+    const elH = finalHeights[i]
     const halfW = elW / 2
     const minLeft = BUBBLE_EDGE_PADDING + halfW
     const maxLeft = viewportWidth - BUBBLE_EDGE_PADDING - halfW
     const rawLeft = anchorX + entry.offsetX
     const clampedLeft = Math.min(Math.max(rawLeft, minLeft), maxLeft)
 
-    const top = currentBottom - elH
-    const clampedTop = Math.max(BUBBLE_EDGE_PADDING, top)
-
     entry.styleLeft = `${clampedLeft}px`
-    entry.styleTop = `${clampedTop}px`
-
-    // 下一个气泡要放在这个气泡上方（留 GAP）
-    currentBottom = clampedTop - BUBBLE_GAP
+    entry.styleTop = `${currentBottom - elH}px`
+    currentBottom = currentBottom - elH - BUBBLE_GAP
   }
 }
 
@@ -727,6 +777,7 @@ function pushBubble(bubbleItems: BubbleRenderableItem[], _position: string, inte
     pinned: false,
     styleLeft: '0px',
     styleTop: '0px',
+    styleMaxHeight: '',
   }
 
   bubbleStack.value.push(entry)
@@ -1955,7 +2006,7 @@ onBeforeUnmount(() => {
   pointer-events: auto;
   /* top/left 由 updateStackPositions 写入，transition 让位置变化平滑 */
   transform: translateX(calc(-50% + var(--bubble-offset-x, 0px)));
-  transition: top 0.3s ease-out, opacity 0.3s, transform 0.3s;
+  transition: top 0.3s ease-out, opacity 0.3s, transform 0.3s, max-height 0.3s ease-out;
 }
 
 /* 层级 1：上一个气泡，稍小稍暗 */
@@ -2371,13 +2422,12 @@ onBeforeUnmount(() => {
 
 
 
-/* TransitionGroup 进入：从下方淡入 */
+/* TransitionGroup 进入：从下方滑入 */
 .bubble-enter-active {
-  transition: opacity 0.3s ease-out, transform 0.35s ease-out;
+  transition: transform 0.35s ease-out;
 }
 
 .bubble-enter-from {
-  opacity: 0;
   transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) translateY(18px) scale(0.92);
 }
 

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -526,7 +526,6 @@ function scheduleBubbleLayoutUpdate() {
 }
 
 function handleBubbleMediaLoad(entryId: string) {
-  // 图片加载完成后重新计算堆叠位置
   nextTick(() => {
     updateStackPositions()
     const el = bubbleContentElMap.get(entryId)
@@ -2102,20 +2101,20 @@ onBeforeUnmount(() => {
 
   /* 滚动条样式 */
   &::-webkit-scrollbar {
-    width: 6px;
+    width: 8px;
   }
 
   &::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(100, 108, 255, 0.5);
-    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.25);
+    border-radius: 4px;
 
     &:hover {
-      background: rgba(100, 108, 255, 0.7);
+      background: rgba(255, 255, 255, 0.4);
     }
   }
 }

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -69,13 +69,36 @@
       </div>
     </Transition>
 
+    <!-- 旧气泡（上移淡出） -->
+    <Transition name="bubble-old">
+      <div
+        v-if="oldBubble"
+        class="bubble bubble-old"
+        :style="{ ...oldBubbleStyle, '--bubble-offset-x': (oldBubble.offsetX ?? 0) + 'px' }"
+        @click.stop
+      >
+        <div class="bubble-content">
+          <div
+            v-for="item in oldBubble.items || []"
+            :key="item.id"
+            :class="['bubble-item', `bubble-item-${item.type}`]"
+          >
+            <div v-if="item.type === 'text'" class="bubble-text" v-html="renderBubbleMarkdown(item.renderedText)"></div>
+            <div v-else-if="item.type === 'image'" class="bubble-image">
+              <img :src="item.src" :alt="item.alt" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- 文字气泡 -->
     <Transition name="bubble">
       <div
         v-if="currentBubble"
         class="bubble"
         ref="bubbleRef"
-        :style="bubbleStyle"
+        :style="{ ...bubbleStyle, '--bubble-offset-x': (currentBubble?.offsetX ?? 0) + 'px' }"
         @click.stop
         @mouseenter="handleBubbleMouseEnter"
         @mouseleave="handleBubbleMouseLeave"
@@ -238,6 +261,7 @@ type BubbleItem = BubbleTextItem | BubbleImageItem
 type BubbleState = {
   position: string
   items: BubbleItem[]
+  offsetX?: number  // 随机水平偏移 px
 }
 
 const connectionStore = useConnectionStore()
@@ -258,7 +282,11 @@ const menuStyle = ref({ left: '0px', top: '0px' })
 const themeColor = ref('rgba(100, 108, 255, 0.8)') // Default accent color
 let menuAutoCloseTimer: number | null = null
 const currentBubble = ref<BubbleState | null>(null)
+const oldBubble = ref<BubbleState | null>(null)
 const bubbleStyle = ref<{ left: string; top?: string; bottom?: string }>({ left: '0px', top: '0px' })
+const oldBubbleStyle = ref<{ left: string; top: string }>({ left: '0px', top: '0px' })
+let oldBubbleHideTimer: number | null = null
+let lastPerformReceiveTime = 0
 const bubbleRef = ref<HTMLElement | null>(null)
 const bubbleContentRef = ref<HTMLElement | null>(null)
 let typewriterTimer: number | null = null
@@ -272,6 +300,8 @@ const TYPEWRITER_LAYOUT_UPDATE_INTERVAL_CHARS = 4
 const BUBBLE_MAX_WIDTH = 450
 const BUBBLE_EDGE_PADDING = 16
 const BUBBLE_VERTICAL_OFFSET = 200
+const OLD_BUBBLE_ABOVE_OFFSET = 130  // 旧气泡在当前气泡锚点上方的额外偏移 px
+const FOLLOW_UP_WINDOW_MS = 4000    // 视为同一轮回复的时间窗口 ms
 const showInput = ref(false)
 const inputRef = ref<HTMLInputElement | null>(null)
 const inputStyle = ref({ left: '0px', top: '0px' })
@@ -630,10 +660,42 @@ async function ensureBubbleTyping(version: number = bubbleSequenceVersion) {
   }
 }
 
+function updateOldBubblePosition() {
+  if (!oldBubble.value) return
+  const offsetX = oldBubble.value.offsetX ?? 0
+  const viewportWidth = window.innerWidth
+  const halfWidth = 180  // 旧气泡宽度估算
+  const minLeft = BUBBLE_EDGE_PADDING + halfWidth
+  const maxLeft = viewportWidth - BUBBLE_EDGE_PADDING - halfWidth
+  const rawLeft = modelPositionX + offsetX
+  const clampedLeft = Math.min(Math.max(rawLeft, minLeft), maxLeft)
+  oldBubbleStyle.value = {
+    left: `${clampedLeft}px`,
+    top: `${modelPositionY - BUBBLE_VERTICAL_OFFSET - OLD_BUBBLE_ABOVE_OFFSET}px`,
+  }
+}
+
+function startOldBubbleHideTimer() {
+  if (oldBubbleHideTimer) clearTimeout(oldBubbleHideTimer)
+  oldBubbleHideTimer = window.setTimeout(() => {
+    oldBubble.value = null
+    oldBubbleHideTimer = null
+  }, 8000)
+}
+
+function clearOldBubble() {
+  if (oldBubbleHideTimer) {
+    clearTimeout(oldBubbleHideTimer)
+    oldBubbleHideTimer = null
+  }
+  oldBubble.value = null
+}
+
 function showPerformBubble(
   bubbleItems: BubbleRenderableItem[],
   position: string,
-  interrupt: boolean
+  interrupt: boolean,
+  isFollowUp: boolean = false
 ) {
   if (!bubbleItems.length) {
     return
@@ -641,11 +703,22 @@ function showPerformBubble(
 
   const runtimeItems = createBubbleItems(bubbleItems)
 
-  if (interrupt || !currentBubble.value) {
+  if (isFollowUp && currentBubble.value) {
+    // 多气泡模式：当前气泡上移成旧气泡，新气泡从下方出现
+    const offsetX = Math.round((Math.random() - 0.5) * 60)  // ±30px
+    oldBubble.value = { ...currentBubble.value, offsetX }
+    updateOldBubblePosition()
+    startOldBubbleHideTimer()
+    resetBubbleTypingState()
+    const newOffsetX = Math.round((Math.random() - 0.5) * 30)  // ±15px
+    currentBubble.value = { position, items: runtimeItems, offsetX: newOffsetX }
+  } else if (interrupt || !currentBubble.value) {
+    clearOldBubble()
     resetBubbleTypingState()
     currentBubble.value = {
       position,
       items: runtimeItems,
+      offsetX: 0,
     }
   } else {
     currentBubble.value.position = currentBubble.value.position || position
@@ -973,6 +1046,11 @@ function updateUIPositions() {
     updateBubblePosition()
   }
 
+  // 同步旧气泡位置（跟随模型移动）
+  if (oldBubble.value) {
+    updateOldBubblePosition()
+  }
+
   // 更新状态提示位置（模型头顶上方 280px）
   if (modelStatus.value) {
     modelStatusStyle.value = {
@@ -1225,6 +1303,7 @@ async function startRecording(options: StartRecordingOptions | MouseEvent = {}) 
 
     await audioRecorder.start()
     isRecording.value = true
+    updateUIPositions()
     currentRecordingSource.value = source
     recordingDuration.value = 0
 
@@ -1521,7 +1600,12 @@ onMounted(async () => {
   window.electron.bridge.onPerformShow((payload: any) => {
     console.log('收到表演指令:', payload)
 
-    const shouldInterrupt = payload.interrupt !== false
+    const now = Date.now()
+    // 同一轮回复（4s 窗口内）的追加消息不中断，做旧气泡上移效果
+    const isFollowUp = currentBubble.value !== null && (now - lastPerformReceiveTime) < FOLLOW_UP_WINDOW_MS
+    lastPerformReceiveTime = now
+
+    const shouldInterrupt = payload.interrupt !== false && !isFollowUp
 
     if (shouldInterrupt) {
       interruptPerformance()
@@ -1539,7 +1623,7 @@ onMounted(async () => {
       )
 
       if (bubbleItems.length > 0) {
-        showPerformBubble(bubbleItems, position, shouldInterrupt)
+        showPerformBubble(bubbleItems, position, shouldInterrupt, isFollowUp)
       }
 
       if (remainingSequence.length > 0) {
@@ -1718,6 +1802,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('storage', handleStorageChange)
   window.removeEventListener('resize', updateUIPositions)
   clearRecordingTimer()
+  clearOldBubble()
 
   if (audioRecorder && isRecording.value) {
     audioRecorder.cancel()
@@ -1919,7 +2004,34 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  transform: translateX(-50%);
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px)));
+}
+
+.bubble-old {
+  z-index: 99;
+  opacity: 0.6;
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.92);
+  filter: blur(0.4px);
+  pointer-events: auto;
+  cursor: default;
+  max-height: min(40vh, calc(100vh - 32px));
+}
+
+.bubble-old-enter-active {
+  transition: opacity 0.35s ease, transform 0.35s ease-out;
+}
+
+.bubble-old-enter-from {
+  opacity: 0;
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) scale(0.9) translateY(15px);
+}
+
+.bubble-old-leave-active {
+  transition: opacity 0.4s ease;
+}
+
+.bubble-old-leave-to {
+  opacity: 0;
 }
 
 .bubble-content {
@@ -2325,7 +2437,7 @@ onBeforeUnmount(() => {
 
 .bubble-enter-from, .bubble-leave-to {
   opacity: 0;
-  transform: translateX(-50%) translateY(20px) scale(0.9);
+  transform: translateX(calc(-50% + var(--bubble-offset-x, 0px))) translateY(20px) scale(0.9);
 }
 
 .input-enter-active, .input-leave-active {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
             outDir: 'dist-electron',
             minify: process.env.NODE_ENV === 'production',
             rollupOptions: {
-              external: ['electron', 'better-sqlite3', 'ws', 'active-win'],
+              external: ['electron', 'better-sqlite3', 'ws'],
               output: {
                 format: 'es'
               }


### PR DESCRIPTION
## Summary
- **重写气泡系统为独立生命周期的气泡栈**：每个气泡独立管理打字机、定时隐藏、鼠标悬停等状态，支持最多 3 个气泡同屏堆叠
- **修复气泡堆叠重叠**：重写 `updateStackPositions` 定位算法，空间不足时自动下移或按比例缩小，绝不重叠
- **修复重复图片破碎图标**：合并服务端发送的同一张图片的 inline + url/rid 两个元素，只渲染一个 `<img>`
- **修复录音气泡位置、快捷键路由**：录音提示跟随模型位置，修复快捷键在非主窗口触发的问题
- **修复打包后窗口检测不可用**：绕过 `@mapbox/node-pre-gyp` 打包问题，改用动态加载 `active-win`
- **优化气泡样式**：增强滚动条可见性，入场动画去掉淡入改为纯滑入

## Changed files
- `src/windows/Main.vue` — 气泡栈系统重写、定位算法、样式优化
- `src/utils/bubbleContent.ts` — 连续互补 image 元素合并逻辑
- `electron/utils/activeWinLoader.ts` — 新增动态加载器绕过打包问题
- `electron/ipc/desktop.ts` / `shortcut.ts` / `main.ts` — 快捷键路由与窗口检测修复
- `vite.config.ts` — 构建配置调整

## Test plan
- [ ] 发送含图片的消息，确认气泡中只显示一张图片（无破碎图标）
- [ ] 发送多条长消息，确认气泡堆叠无重叠，空间不足时自动下移/缩小
- [ ] 确认气泡入场无淡入半透明，直接滑入
- [ ] 确认气泡内容可滚动，滚动条可见
- [ ] 打包后测试窗口检测功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rewrite the desktop bubble system into a stacked, independently managed bubble lifecycle and fix packaging and window-detection related issues.

New Features:
- Introduce a multi-bubble stack that supports up to three independently typed and auto-hidden bubbles with layered visual styling and smooth transitions.

Bug Fixes:
- Prevent bubble overlap by recalculating stacked bubble positions with dynamic sizing based on viewport space.
- Fix duplicate or broken images in bubbles by merging complementary image elements from the server into a single rendered image.
- Correct recording bubble positioning to follow the model and ensure global shortcuts are routed only to the main window.
- Restore active window detection in packaged builds by bypassing the failing @mapbox/node-pre-gyp resolution and loading active-win bindings directly.

Enhancements:
- Improve bubble visuals with tiered opacity/scale, clearer scrollbars, and a slide-only entrance/exit animation.
- Refine performance handling so follow-up perform messages within a short window append as additional bubbles instead of interrupting the previous content.

Build:
- Adjust Vite/Electron bundling configuration to stop treating active-win as an external dependency so it can be loaded via a custom native binding loader.