### PR TITLE
fix: 修复 TTS 链路与历史语音消息展示

### DIFF
--- a/electron/protocol/client.ts
+++ b/electron/protocol/client.ts
@@ -407,7 +407,14 @@ export class L2DBridgeClient extends EventEmitter {
     const MAX_STRING_LEN = 200
 
     const sanitize = (obj: any): any => {
-      if (Array.isArray(obj)) return `[Array:${obj.length}]`
+      if (Array.isArray(obj)) {
+        const preview = obj.slice(0, 3).map(item => sanitize(item))
+        return {
+          __type: 'array',
+          length: obj.length,
+          preview,
+        }
+      }
       if (!obj || typeof obj !== 'object') {
         if (typeof obj === 'string' && obj.length > MAX_STRING_LEN) {
           return obj.slice(0, MAX_STRING_LEN) + '...'

--- a/electron/protocol/client.ts
+++ b/electron/protocol/client.ts
@@ -405,34 +405,55 @@ export class L2DBridgeClient extends EventEmitter {
     if (!payload || typeof payload !== 'object') return payload
     const sensitiveKeys = ['token', 'password', 'secret', 'apiKey', 'accessKey']
     const MAX_STRING_LEN = 200
+    const MAX_PREVIEW_ITEMS = 3
+    const MAX_DEPTH = 4
 
-    const sanitize = (obj: any): any => {
-      if (Array.isArray(obj)) {
-        const preview = obj.slice(0, 3).map(item => sanitize(item))
-        return {
-          __type: 'array',
-          length: obj.length,
-          preview,
-        }
-      }
+    const sanitize = (obj: any, seen: WeakSet<object>, depth: number): any => {
       if (!obj || typeof obj !== 'object') {
         if (typeof obj === 'string' && obj.length > MAX_STRING_LEN) {
           return obj.slice(0, MAX_STRING_LEN) + '...'
         }
         return obj
       }
+
+      if (seen.has(obj)) {
+        return '[Circular]'
+      }
+
+      if (depth >= MAX_DEPTH) {
+        if (Array.isArray(obj)) {
+          return `[Array:${obj.length}]`
+        }
+        return '[Object]'
+      }
+
+      seen.add(obj)
+      if (Array.isArray(obj)) {
+        const preview = obj
+          .slice(0, MAX_PREVIEW_ITEMS)
+          .map(item => sanitize(item, seen, depth + 1))
+        const result = {
+          __type: 'array',
+          length: obj.length,
+          preview,
+        }
+        seen.delete(obj)
+        return result
+      }
+
       const result: Record<string, any> = {}
       for (const [key, value] of Object.entries(obj)) {
         if (sensitiveKeys.some(k => key.toLowerCase().includes(k))) {
           result[key] = '***'
         } else {
-          result[key] = sanitize(value)
+          result[key] = sanitize(value, seen, depth + 1)
         }
       }
+      seen.delete(obj)
       return result
     }
 
-    return sanitize(payload)
+    return sanitize(payload, new WeakSet<object>(), 0)
   }
 
   /**

--- a/src/utils/bubbleContent.ts
+++ b/src/utils/bubbleContent.ts
@@ -3,6 +3,7 @@ import { resolveResourceSource, type ResourceUrlConfig } from './resourceUrl'
 export interface BubblePerformElement {
   type?: string
   content?: string
+  text?: string
   position?: string
   url?: string
   inline?: string
@@ -50,6 +51,24 @@ function mergeConsecutiveImages(sequence: BubblePerformElement[]): BubblePerform
   return result
 }
 
+function normalizeBubbleText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function appendBubbleTextItem(items: BubbleRenderableItem[], text: string): void {
+  const normalizedText = normalizeBubbleText(text)
+  if (!normalizedText) {
+    return
+  }
+
+  const lastItem = items[items.length - 1]
+  if (lastItem?.type === 'text' && normalizeBubbleText(lastItem.text) === normalizedText) {
+    return
+  }
+
+  items.push({ type: 'text', text })
+}
+
 export function splitPerformSequenceForBubble(
   sequence: BubblePerformElement[] | null | undefined,
   options: ResourceUrlConfig = {}
@@ -61,19 +80,32 @@ export function splitPerformSequenceForBubble(
 
   for (const element of mergeConsecutiveImages(sequence || [])) {
     const type = String(element?.type || '')
+    const textContent = typeof element.content === 'string' ? element.content : ''
+    const ttsText = typeof element.text === 'string' ? element.text : ''
 
-    if (!hasBubblePosition && (type === 'text' || type === 'image')) {
+    if (!hasBubblePosition && (
+      type === 'text' ||
+      type === 'image' ||
+      (type === 'tts' && normalizeBubbleText(ttsText))
+    )) {
       const nextPosition = typeof element.position === 'string' ? element.position.trim() : ''
       position = nextPosition || 'center'
       hasBubblePosition = true
     }
 
     if (type === 'text') {
-      const text = typeof element.content === 'string' ? element.content : ''
-      if (text) {
-        bubbleItems.push({ type: 'text', text })
+      if (normalizeBubbleText(textContent)) {
+        appendBubbleTextItem(bubbleItems, textContent)
         continue
       }
+    }
+
+    if (type === 'tts') {
+      if (normalizeBubbleText(ttsText)) {
+        appendBubbleTextItem(bubbleItems, ttsText)
+      }
+      remainingSequence.push(element)
+      continue
     }
 
     if (type === 'image') {

--- a/src/utils/historyContent.ts
+++ b/src/utils/historyContent.ts
@@ -154,7 +154,7 @@ export function buildHistoryRenderableItems(
 
       const src = resolveHistoryMediaSource(element, options)
       if (src) {
-        items.push({ type: 'audio', src, label: element.name || text || '语音消息' })
+        items.push({ type: 'audio', src, label: element.name || '语音消息' })
       }
       continue
     }

--- a/src/utils/historyContent.ts
+++ b/src/utils/historyContent.ts
@@ -17,6 +17,34 @@ export type HistoryRenderableItem =
   | { type: 'video'; src: string; label: string }
   | { type: 'file'; src: string; label: string; name: string }
 
+function normalizeHistoryText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function getHistoryElementText(element: HistoryContentElement | null | undefined): string {
+  if (typeof element?.text === 'string') {
+    return element.text
+  }
+  if (typeof element?.content === 'string') {
+    return element.content
+  }
+  return ''
+}
+
+function appendHistoryTextItem(items: HistoryRenderableItem[], text: string): void {
+  const normalizedText = normalizeHistoryText(text)
+  if (!normalizedText) {
+    return
+  }
+
+  const lastItem = items[items.length - 1]
+  if (lastItem?.type === 'text' && normalizeHistoryText(lastItem.text) === normalizedText) {
+    return
+  }
+
+  items.push({ type: 'text', text })
+}
+
 export function setLruCacheEntry<T>(cache: Map<string, T>, key: string, value: T, limit: number): T {
   if (cache.has(key)) {
     cache.delete(key)
@@ -78,6 +106,32 @@ export function resolveHistoryImageSource(
   return resolveHistoryMediaSource(element, resourceConfig)
 }
 
+export function extractHistoryRawText(
+  content: HistoryContentElement[] | null | undefined,
+): string {
+  const parts: string[] = []
+
+  for (const element of content || []) {
+    const type = String(element?.type || '')
+    if (type !== 'text' && type !== 'tts') {
+      continue
+    }
+
+    const text = normalizeHistoryText(getHistoryElementText(element))
+    if (!text) {
+      continue
+    }
+
+    if (parts[parts.length - 1] === text) {
+      continue
+    }
+
+    parts.push(text)
+  }
+
+  return parts.join('\n')
+}
+
 export function buildHistoryRenderableItems(
   content: HistoryContentElement[] | null | undefined,
   options: { includeTtsText?: boolean } & ResourceUrlConfig = {}
@@ -86,16 +140,21 @@ export function buildHistoryRenderableItems(
 
   for (const element of content || []) {
     const type = String(element?.type || '')
+    const text = getHistoryElementText(element)
 
-    if (type === 'text' || (options.includeTtsText && type === 'tts')) {
-      const text = typeof element.text === 'string'
-        ? element.text
-        : typeof element.content === 'string'
-          ? element.content
-          : ''
+    if (type === 'text') {
+      appendHistoryTextItem(items, text)
+      continue
+    }
 
-      if (text) {
-        items.push({ type: 'text', text })
+    if (type === 'tts') {
+      if (options.includeTtsText) {
+        appendHistoryTextItem(items, text)
+      }
+
+      const src = resolveHistoryMediaSource(element, options)
+      if (src) {
+        items.push({ type: 'audio', src, label: element.name || text || '语音消息' })
       }
       continue
     }

--- a/src/windows/History.vue
+++ b/src/windows/History.vue
@@ -213,81 +213,54 @@
                         </div>
                       </div>
                       <div v-else>
-                        <div v-for="(item, idx) in parseContent(msg.content)" :key="idx" class="content-item">
+                        <div v-for="(item, idx) in getMessagePreviewItems(msg.content)" :key="idx" class="content-item">
                           <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
                           <div v-else-if="item.type === 'image'" class="image-content">
-                            <n-image
-                              v-if="resolveMessageImageSource(item)"
-                              :src="resolveMessageImageSource(item) || undefined"
-                              width="200"
-                              object-fit="cover"
-                            />
-                            <div v-else class="image-placeholder">
-                              <n-icon size="40"><ImageIcon /></n-icon>
-                              <span>图片</span>
-                            </div>
+                            <n-image :src="item.src" width="200" object-fit="cover" />
                           </div>
                           <div v-else-if="item.type === 'audio'" class="audio-content">
-                            <template v-if="resolveMessageAudioSource(item)">
-                              <div class="media-content-header">
-                                <n-icon size="18"><Mic /></n-icon>
-                                <span>{{ item.name || '语音消息' }}</span>
-                              </div>
-                              <audio
-                                class="audio-player"
-                                :src="resolveMessageAudioSource(item) || undefined"
-                                controls
-                                preload="metadata"
-                                @click.stop
-                              ></audio>
-                            </template>
-                            <div v-else class="media-placeholder">
-                              <n-icon size="20"><Mic /></n-icon>
-                              <span>语音消息</span>
+                            <div class="media-content-header">
+                              <n-icon size="18"><Mic /></n-icon>
+                              <span>{{ item.label }}</span>
                             </div>
+                            <audio
+                              class="audio-player"
+                              :src="item.src"
+                              controls
+                              preload="metadata"
+                              @click.stop
+                            ></audio>
                           </div>
                           <div v-else-if="item.type === 'video'" class="video-content">
-                            <template v-if="resolveMessageVideoSource(item)">
-                              <div class="media-content-header">
-                                <n-icon size="18"><Video /></n-icon>
-                                <span>{{ item.name || '视频' }}</span>
-                              </div>
-                              <video
-                                class="video-player"
-                                :src="resolveMessageVideoSource(item) || undefined"
-                                controls
-                                preload="metadata"
-                                playsinline
-                                @click.stop
-                              ></video>
-                            </template>
-                            <div v-else class="media-placeholder">
-                              <n-icon size="20"><Video /></n-icon>
-                              <span>视频</span>
+                            <div class="media-content-header">
+                              <n-icon size="18"><Video /></n-icon>
+                              <span>{{ item.label }}</span>
                             </div>
+                            <video
+                              class="video-player"
+                              :src="item.src"
+                              controls
+                              preload="metadata"
+                              playsinline
+                              @click.stop
+                            ></video>
                           </div>
                           <div v-else-if="item.type === 'file'" class="file-content">
-                            <template v-if="resolveMessageFileSource(item)">
-                              <div class="file-header">
-                                <div class="file-meta">
-                                  <n-icon size="18"><FileText /></n-icon>
-                                  <span class="file-name">{{ item.name || '文件' }}</span>
-                                </div>
-                                <div class="file-actions">
-                                  <button class="file-action-btn" @click.stop="openHistoryFile(item)">
-                                    <ExternalLink :size="14" />
-                                    <span>打开</span>
-                                  </button>
-                                  <button class="file-action-btn" @click.stop="downloadHistoryFile(item)">
-                                    <Download :size="14" />
-                                    <span>下载</span>
-                                  </button>
-                                </div>
+                            <div class="file-header">
+                              <div class="file-meta">
+                                <n-icon size="18"><FileText /></n-icon>
+                                <span class="file-name">{{ item.name }}</span>
                               </div>
-                            </template>
-                            <div v-else class="media-placeholder">
-                              <n-icon size="20"><FileText /></n-icon>
-                              <span>{{ item.name || '文件' }}</span>
+                              <div class="file-actions">
+                                <button class="file-action-btn" @click.stop="openHistoryFile(item)">
+                                  <ExternalLink :size="14" />
+                                  <span>打开</span>
+                                </button>
+                                <button class="file-action-btn" @click.stop="downloadHistoryFile(item)">
+                                  <Download :size="14" />
+                                  <span>下载</span>
+                                </button>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -340,8 +313,6 @@ import {
   buildHistoryRenderableItems,
   getLruCacheEntry,
   parseHistoryContent,
-  resolveHistoryMediaSource,
-  resolveHistoryImageSource,
   setLruCacheEntry,
   type HistoryContentElement,
   type HistoryRenderableItem,
@@ -486,6 +457,7 @@ const CONTENT_CACHE_LIMIT = 1000
 const PREVIEW_CACHE_LIMIT = 500
 const markdownRenderCache = new Map<string, string>()
 const messageContentCache = new Map<string, HistoryContentElement[]>()
+const messagePreviewCache = new Map<string, HistoryRenderableItem[]>()
 const performancePreviewCache = new Map<string, HistoryRenderableItem[]>()
 const historyResourceBaseUrl = ref('')
 const historyResourcePath = ref('/resources')
@@ -499,6 +471,27 @@ function buildPerformanceCacheKey(content: string): string {
   }
 
   return `${historyResourceBaseUrl.value}::${historyResourcePath.value}::${historyResourceToken.value}::${content.length}::${hash}`
+}
+
+function getMessagePreviewItems(content: string): HistoryRenderableItem[] {
+  const cacheKey = `message::${buildPerformanceCacheKey(content)}`
+  const cached = getLruCacheEntry(messagePreviewCache, cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  try {
+    const parsed = parseContent(content)
+    const items = buildHistoryRenderableItems(parsed, {
+      includeTtsText: true,
+      resourceBaseUrl: historyResourceBaseUrl.value,
+      resourcePath: historyResourcePath.value,
+      resourceToken: historyResourceToken.value,
+    })
+    return setLruCacheEntry(messagePreviewCache, cacheKey, items, PREVIEW_CACHE_LIMIT)
+  } catch {
+    return setLruCacheEntry(messagePreviewCache, cacheKey, [], PREVIEW_CACHE_LIMIT)
+  }
 }
 
 onMounted(async () => {
@@ -530,6 +523,7 @@ onUnmounted(() => {
   charts = []
   markdownRenderCache.clear()
   messageContentCache.clear()
+  messagePreviewCache.clear()
   performancePreviewCache.clear()
   connectionStore.stopStorageSync()
   themeStore.stopStorageSync()
@@ -1047,7 +1041,7 @@ function isPerformanceMessage(msg: any): boolean {
 }
 
 function getPerformancePreviewItems(content: string): HistoryRenderableItem[] {
-  const cacheKey = buildPerformanceCacheKey(content)
+  const cacheKey = `performance::${buildPerformanceCacheKey(content)}`
   const cached = getLruCacheEntry(performancePreviewCache, cacheKey)
   if (cached !== undefined) {
     return cached
@@ -1067,44 +1061,11 @@ function getPerformancePreviewItems(content: string): HistoryRenderableItem[] {
   }
 }
 
-function resolveMessageImageSource(item: any): string | null {
-  return resolveHistoryImageSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageAudioSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageVideoSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageFileSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
 function getHistoryFileSource(item: any): string | null {
   if (typeof item?.src === 'string' && item.src.trim()) {
     return item.src.trim()
   }
-
-  return resolveMessageFileSource(item)
+  return null
 }
 
 function getHistoryFileName(item: any): string {

--- a/src/windows/History.vue
+++ b/src/windows/History.vue
@@ -171,7 +171,7 @@
                           <div
                             v-for="(item, previewIdx) in getPerformancePreviewItems(msg.content)"
                             :key="previewIdx"
-                            class="content-item performance-preview-item"
+                            :class="['content-item', 'performance-preview-item', `content-item--${item.type}`]"
                           >
                             <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
                             <div v-else-if="item.type === 'image'" class="image-content performance-image-content">
@@ -213,7 +213,11 @@
                         </div>
                       </div>
                       <div v-else>
-                        <div v-for="(item, idx) in getMessagePreviewItems(msg.content)" :key="idx" class="content-item">
+                        <div
+                          v-for="(item, idx) in getMessagePreviewItems(msg.content)"
+                          :key="idx"
+                          :class="['content-item', `content-item--${item.type}`]"
+                        >
                           <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
                           <div v-else-if="item.type === 'image'" class="image-content">
                             <n-image :src="item.src" width="200" object-fit="cover" />
@@ -1607,6 +1611,7 @@ function handleTitleBarDoubleClick() {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  align-items: flex-start;
 }
 
 .message-time {
@@ -1618,14 +1623,16 @@ function handleTitleBarDoubleClick() {
 }
 
 .content-item {
-  margin-bottom: 8px;
-}
-
-.content-item:last-child {
-  margin-bottom: 0;
+  max-width: 100%;
 }
 
 .text-content {
+  width: fit-content;
+  max-width: min(100%, 760px);
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   line-height: 1.6;
   font-size: 13px;
   white-space: pre-wrap;
@@ -1680,6 +1687,20 @@ function handleTitleBarDoubleClick() {
       border-bottom-style: solid;
     }
   }
+}
+
+.message-item--outgoing .message-record__body {
+  align-items: flex-end;
+}
+
+.message-item--incoming .content-item--text .text-content {
+  border-bottom-left-radius: 4px;
+}
+
+.message-item--outgoing .content-item--text .text-content {
+  background: linear-gradient(180deg, rgba(var(--color-accent-rgb), 0.12), rgba(var(--color-accent-rgb), 0.08));
+  border-color: rgba(var(--color-accent-rgb), 0.18);
+  border-bottom-right-radius: 4px;
 }
 
 .image-content {
@@ -1763,6 +1784,9 @@ function handleTitleBarDoubleClick() {
 
 .performance-text-preview {
   margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   padding: 12px;
   background: rgba(255, 255, 255, 0.02);
   border-radius: 10px;
@@ -1875,10 +1899,6 @@ function handleTitleBarDoubleClick() {
 .performance-file-content,
 .performance-image-content {
   margin-top: 0;
-}
-
-.performance-preview-item + .performance-preview-item {
-  margin-top: 10px;
 }
 
 @media (max-width: 1080px) {

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -226,6 +226,7 @@ import {
   resolvePerformMediaSource,
   splitPerformSequenceForBubble,
 } from '@/utils/bubbleContent'
+import { extractHistoryRawText } from '@/utils/historyContent'
 import { configureMarked, renderBubbleMarkdown } from '@/utils/markedLatex'
 import { extractModelThemeColor } from '@/utils/modelTheme'
 import { sleep } from '@/utils/async'
@@ -975,6 +976,7 @@ onMounted(async () => {
         const dateStr = date.toISOString().split('T')[0]
         const hour = date.getHours()
         const performanceId = generateMessageId('perf')
+        const rawText = extractHistoryRawText(payload.sequence) || '[表演序列]'
 
         // 先保存一条incoming消息记录（服务器发来的表演）
         window.electron.history.saveMessage({
@@ -985,7 +987,7 @@ onMounted(async () => {
           messageType: 'friend',
           direction: 'incoming',
           content: payload.sequence,
-          rawText: '[表演序列]',
+          rawText,
           timestamp: timestamp
         }).then(() => {
           // 保存表演记录（关联到消息）

--- a/src/windows/Settings.vue
+++ b/src/windows/Settings.vue
@@ -361,70 +361,57 @@
                     </div>
 
                     <div class="message-bubble__body">
-                      <div v-for="(item, idx) in parseContent(msg.content)" :key="idx" class="content-item">
-                        <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text || item.content)"></div>
+                      <div v-for="(item, idx) in getMessagePreviewItems(msg.content)" :key="idx" class="content-item">
+                        <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
                         <div v-else-if="item.type === 'image'" class="image-content">
                           <n-image
-                            v-if="resolveMessageImageSource(item)"
-                            :src="resolveMessageImageSource(item) || undefined"
-                            :preview-src="resolveMessageImageSource(item) || undefined"
+                            :src="item.src"
+                            :preview-src="item.src"
                             width="220"
                             object-fit="cover"
                             preview-disabled
                             :lazy="true"
                           />
-                          <div v-else class="media-placeholder">
-                            <ImageIcon :size="16" />
-                            <span>图片</span>
-                          </div>
                         </div>
-                        <div v-else-if="item.type === 'audio'" class="voice-bubble" @click="toggleVoicePlay(item, idx)">
+                        <div
+                          v-else-if="item.type === 'audio'"
+                          class="voice-bubble"
+                          :class="{ playing: playingVoiceKey === getVoiceItemKey(msg, idx) }"
+                          @click="toggleVoicePlay(getVoiceItemKey(msg, idx))"
+                        >
                           <div class="voice-bubble__icon">
                             <Mic :size="16" />
                           </div>
                           <div class="voice-bubble__wave">
                             <span></span><span></span><span></span><span></span><span></span>
                           </div>
-                          <span class="voice-bubble__duration">{{ item.duration || "''" }}</span>
+                          <span class="voice-bubble__duration">{{ item.label }}</span>
                           <audio
-                            :ref="el => setVoiceRef(el, idx)"
-                            :src="resolveMessageAudioSource(item) || undefined"
+                            :ref="el => setVoiceRef(el, getVoiceItemKey(msg, idx))"
+                            :src="item.src"
                             preload="metadata"
-                            @ended="onVoiceEnded(idx)"
+                            @ended="onVoiceEnded(getVoiceItemKey(msg, idx))"
                           ></audio>
                         </div>
                         <div v-else-if="item.type === 'video'" class="video-content">
-                          <template v-if="resolveMessageVideoSource(item)">
-                            <video class="video-player" :src="resolveMessageVideoSource(item) || undefined" controls preload="metadata" playsinline></video>
-                          </template>
-                          <div v-else class="media-placeholder">
-                            <Video :size="16" />
-                            <span>视频</span>
-                          </div>
+                          <video class="video-player" :src="item.src" controls preload="metadata" playsinline></video>
                         </div>
                         <div v-else-if="item.type === 'file'" class="file-content">
-                          <template v-if="resolveMessageFileSource(item)">
-                            <div class="file-header">
-                              <div class="file-meta">
-                                <FileText :size="16" />
-                                <span class="file-name">{{ item.name || '文件' }}</span>
-                              </div>
-                              <div class="file-actions">
-                                <button class="file-action-btn" @click="openHistoryFile(item)">
-                                  <ExternalLink :size="12" />
-                                </button>
-                                <button class="file-action-btn" @click="downloadHistoryFile(item)">
-                                  <Download :size="12" />
-                                </button>
-                              </div>
+                          <div class="file-header">
+                            <div class="file-meta">
+                              <FileText :size="16" />
+                              <span class="file-name">{{ item.name }}</span>
                             </div>
-                          </template>
-                          <div v-else class="media-placeholder">
-                            <FileText :size="16" />
-                            <span>{{ item.name || '文件' }}</span>
+                            <div class="file-actions">
+                              <button class="file-action-btn" @click="openHistoryFile(item)">
+                                <ExternalLink :size="12" />
+                              </button>
+                              <button class="file-action-btn" @click="downloadHistoryFile(item)">
+                                <Download :size="12" />
+                              </button>
+                            </div>
                           </div>
                         </div>
-                        <div v-else class="text-content">{{ item.type }}</div>
                       </div>
                     </div>
                   </div>
@@ -999,7 +986,7 @@ import * as echarts from 'echarts'
 import { format } from 'date-fns'
 import {
   Copy, Drama, Globe, Info, Minus, Settings, Square, X,
-  MessageSquare, Search, User, Bot, Image as ImageIcon, Mic, Video,
+  MessageSquare, Search, User, Bot, Mic,
   FileText, ExternalLink, Download
 } from 'lucide-vue-next'
 import { useConnectionStore } from '@/stores/connection'
@@ -1018,12 +1005,12 @@ import {
   saveAdvancedSettings as persistAdvancedSettings,
 } from '@/utils/advancedSettings'
 import {
+  buildHistoryRenderableItems,
   getLruCacheEntry,
   setLruCacheEntry,
-  resolveHistoryMediaSource,
   parseHistoryContent,
-  resolveHistoryImageSource,
   type HistoryContentElement,
+  type HistoryRenderableItem,
 } from '@/utils/historyContent'
 import { withAlpha } from '@/utils/themePalette'
 import { DEFAULT_DESKTOP_FEATURE_SETTINGS } from '@/utils/desktopFeatureSettings'
@@ -1192,49 +1179,57 @@ const activeHoursRef = ref<HTMLElement>()
 let charts: echarts.ECharts[] = []
 
 // 语音播放状态
-const voiceRefs = new Map<number, HTMLAudioElement>()
-const playingVoiceIdx = ref<number | null>(null)
+const voiceRefs = new Map<string, HTMLAudioElement>()
+const playingVoiceKey = ref<string | null>(null)
 
-function setVoiceRef(el: any, idx: number) {
+function setVoiceRef(el: any, key: string) {
   if (el) {
-    voiceRefs.set(idx, el as HTMLAudioElement)
+    voiceRefs.set(key, el as HTMLAudioElement)
   } else {
-    voiceRefs.delete(idx)
+    voiceRefs.delete(key)
   }
 }
 
-function toggleVoicePlay(_item: any, idx: number) {
-  const audio = voiceRefs.get(idx)
+function toggleVoicePlay(key: string) {
+  const audio = voiceRefs.get(key)
   if (!audio) return
 
   // 停止其他正在播放的语音
-  if (playingVoiceIdx.value !== null && playingVoiceIdx.value !== idx) {
-    const prevAudio = voiceRefs.get(playingVoiceIdx.value)
+  if (playingVoiceKey.value !== null && playingVoiceKey.value !== key) {
+    const prevAudio = voiceRefs.get(playingVoiceKey.value)
     if (prevAudio) {
       prevAudio.pause()
       prevAudio.currentTime = 0
     }
+    playingVoiceKey.value = null
   }
 
-  if (playingVoiceIdx.value === idx) {
+  if (playingVoiceKey.value === key) {
     audio.pause()
     audio.currentTime = 0
-    playingVoiceIdx.value = null
+    playingVoiceKey.value = null
   } else {
-    audio.play().catch(() => {})
-    playingVoiceIdx.value = idx
+    audio.play().then(() => {
+      playingVoiceKey.value = key
+    }).catch((error) => {
+      console.error('[设置] 语音播放失败:', error)
+      message.error('语音播放失败')
+      playingVoiceKey.value = null
+    })
   }
 }
 
-function onVoiceEnded(idx: number) {
-  if (playingVoiceIdx.value === idx) {
-    playingVoiceIdx.value = null
+function onVoiceEnded(key: string) {
+  if (playingVoiceKey.value === key) {
+    playingVoiceKey.value = null
   }
 }
 
 // 缓存
+const HISTORY_PREVIEW_CACHE_LIMIT = 500
 const markdownRenderCache = new Map<string, string>()
 const messageContentCache = new Map<string, HistoryContentElement[]>()
+const messagePreviewCache = new Map<string, HistoryRenderableItem[]>()
 
 // 计算属性
 const activeGroupMeta = computed(() => {
@@ -1478,8 +1473,15 @@ onMounted(async () => {
 onUnmounted(() => {
   charts.forEach(chart => chart.dispose())
   charts = []
+  for (const audio of voiceRefs.values()) {
+    audio.pause()
+    audio.currentTime = 0
+  }
+  voiceRefs.clear()
+  playingVoiceKey.value = null
   markdownRenderCache.clear()
   messageContentCache.clear()
+  messagePreviewCache.clear()
   themeStore.stopStorageSync()
   for (const dispose of settingsWindowDisposers.splice(0)) {
     dispose()
@@ -2037,47 +2039,51 @@ function parseContent(content: string): any[] {
   return parseHistoryContent(content, messageContentCache, 1000)
 }
 
+function buildHistoryPreviewCacheKey(content: string): string {
+  let hash = 0
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) - hash) + content.charCodeAt(i)
+    hash |= 0
+  }
+
+  return `${historyResourceBaseUrl.value}::${historyResourcePath.value}::${historyResourceToken.value}::${content.length}::${hash}`
+}
+
+function getMessagePreviewItems(content: string): HistoryRenderableItem[] {
+  const cacheKey = buildHistoryPreviewCacheKey(content)
+  const cached = getLruCacheEntry(messagePreviewCache, cacheKey)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  try {
+    const parsed = parseContent(content)
+    const items = buildHistoryRenderableItems(parsed, {
+      includeTtsText: true,
+      resourceBaseUrl: historyResourceBaseUrl.value,
+      resourcePath: historyResourcePath.value,
+      resourceToken: historyResourceToken.value,
+    })
+    return setLruCacheEntry(messagePreviewCache, cacheKey, items, HISTORY_PREVIEW_CACHE_LIMIT)
+  } catch {
+    return setLruCacheEntry(messagePreviewCache, cacheKey, [], HISTORY_PREVIEW_CACHE_LIMIT)
+  }
+}
+
+function getVoiceItemKey(msg: any, idx: number): string {
+  const messageKey = msg?.message_id || msg?.messageId || msg?.id || msg?.timestamp || 'message'
+  return `${messageKey}:${idx}`
+}
+
 function getMessageAuthorLabel(msg: any): string {
   if (msg.direction === 'outgoing') return msg.user_name || '我'
   if (msg.user_id === 'server' || msg.user_id === 'bot') return 'AstrBot'
   return msg.user_name || msg.user_id || '未知来源'
 }
 
-function resolveMessageImageSource(item: any): string | null {
-  return resolveHistoryImageSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageAudioSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageVideoSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
-function resolveMessageFileSource(item: any): string | null {
-  return resolveHistoryMediaSource(item, {
-    resourceBaseUrl: historyResourceBaseUrl.value,
-    resourcePath: historyResourcePath.value,
-    resourceToken: historyResourceToken.value,
-  })
-}
-
 function getHistoryFileSource(item: any): string | null {
   if (typeof item?.src === 'string' && item.src.trim()) return item.src.trim()
-  return resolveMessageFileSource(item)
+  return null
 }
 
 function getHistoryFileName(item: any): string {
@@ -3207,7 +3213,6 @@ function handleOpenLink(url: string) {
   background: rgba(var(--color-accent-rgb), 0.6);
 }
 
-.voice-bubble:hover .voice-bubble__wave span,
 .voice-bubble.playing .voice-bubble__wave span {
   animation: voiceWave 0.6s ease-in-out infinite alternate;
 

--- a/src/windows/Settings.vue
+++ b/src/windows/Settings.vue
@@ -361,7 +361,11 @@
                     </div>
 
                     <div class="message-bubble__body">
-                      <div v-for="(item, idx) in getMessagePreviewItems(msg.content)" :key="idx" class="content-item">
+                      <div
+                        v-for="(item, idx) in getMessagePreviewItems(msg.content)"
+                        :key="idx"
+                        :class="['content-item', `content-item--${item.type}`]"
+                      >
                         <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
                         <div v-else-if="item.type === 'image'" class="image-content">
                           <n-image
@@ -3029,20 +3033,6 @@ function handleOpenLink(url: string) {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--desktop-panel-border);
-}
-
-.message-item--outgoing .message-bubble {
-  background: rgba(var(--color-accent-rgb), 0.08);
-  border-color: rgba(var(--color-accent-rgb), 0.15);
-  border-bottom-right-radius: 4px;
-}
-
-.message-item--incoming .message-bubble {
-  border-bottom-left-radius: 4px;
 }
 
 .message-bubble__header {
@@ -3050,6 +3040,11 @@ function handleOpenLink(url: string) {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  padding: 0 4px;
+}
+
+.message-item--outgoing .message-bubble__header {
+  justify-content: flex-end;
 }
 
 .message-bubble__name {
@@ -3067,17 +3062,24 @@ function handleOpenLink(url: string) {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  align-items: flex-start;
 }
 
 .content-item {
-  margin-bottom: 4px;
+  max-width: 100%;
 }
 
-.content-item:last-child {
-  margin-bottom: 0;
+.message-item--outgoing .message-bubble__body {
+  align-items: flex-end;
 }
 
 .text-content {
+  width: fit-content;
+  max-width: min(100%, 420px);
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--desktop-panel-border);
   line-height: 1.5;
   font-size: 12px;
   white-space: pre-wrap;
@@ -3112,6 +3114,16 @@ function handleOpenLink(url: string) {
       color: #d4d4d4;
     }
   }
+}
+
+.message-item--incoming .content-item--text .text-content {
+  border-bottom-left-radius: 4px;
+}
+
+.message-item--outgoing .content-item--text .text-content {
+  background: rgba(var(--color-accent-rgb), 0.08);
+  border-color: rgba(var(--color-accent-rgb), 0.15);
+  border-bottom-right-radius: 4px;
 }
 
 .image-content {


### PR DESCRIPTION
## 目标
- 修复 TTS 链路在桌面端历史消息中的文字显示与语音播放问题
- 修复历史语音消息动画触发时机与展示样式问题
- 提升协议日志可读性，便于后续定位 TTS 数据包

## 变更
- 修复 TTS 文本在实时气泡、历史记录和 rawText 中的传递链路
- 将历史消息中的文字内容与语音内容拆分为独立消息气泡显示
- 调整历史语音播放动效，仅在点击播放后启动，播放结束后停止
- 优化桌面端 perform.show 日志预览，避免 sequence 被折叠成不可读的数组占位

## 验证
- pnpm run typecheck

## Summary by Sourcery

Update desktop history and settings message rendering to correctly handle TTS text and audio, and improve protocol logging readability.

Bug Fixes:
- Ensure TTS text is correctly extracted and shown in both real-time bubbles and desktop history while keeping associated audio playable.
- Fix voice message playback animation so it only runs during active playback and stops when audio ends.

Enhancements:
- Unify and cache history message preview items for text, media, and TTS, simplifying media source resolution and improving performance.
- Refine history and settings UI layouts so text, audio, image, and file messages render as distinct, better-aligned bubbles for incoming and outgoing messages.
- Improve perform.show protocol log serialization by providing structured previews of arrays instead of opaque placeholders.
- Derive rawText for saved performance messages from their underlying text and TTS content for better searchability and diagnostics.