### PR TITLE
fix: 修复 Windows 安装版与便携版发布链路

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
               release/astrbot-live2d-desktop-v*-portable-x64.exe
               release/*.blockmap
               release/latest.yml
+              release/latest-portable-x64.yml
           - os: windows-latest
             rebuild_platform: win32
             arch: arm64
@@ -124,6 +125,7 @@ jobs:
               release/astrbot-live2d-desktop-v*-win-arm64.exe
               release/astrbot-live2d-desktop-v*-portable-arm64.exe
               release/*.blockmap
+              release/latest-portable-arm64.yml
           - os: macos-latest
             rebuild_platform: darwin
             arch: x64
@@ -201,6 +203,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+
+      - name: Generate portable update metadata
+        if: startsWith(matrix.os, 'windows')
+        run: node scripts/generate-portable-update-metadata.mjs --arch=${{ matrix.arch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/electron/utils/updater.ts
+++ b/electron/utils/updater.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog } from 'electron'
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { writeLogEntry } from './logger'
@@ -31,6 +32,16 @@ interface UpdateCheckResult {
   state: UpdateState
 }
 
+interface InstallUpdateResult {
+  success: boolean
+  message: string
+}
+
+interface AutoUpdaterWithInternals {
+  channel?: string | null
+  installerPath?: string | null
+}
+
 let initialized = false
 let checkInProgress = false
 
@@ -44,12 +55,167 @@ function isPortableBuild(): boolean {
   return process.platform === 'win32' && Boolean(process.env.PORTABLE_EXECUTABLE_FILE)
 }
 
+function getPortableExecutablePath(): string | null {
+  if (!isPortableBuild()) {
+    return null
+  }
+
+  const portableExecutablePath = process.env.PORTABLE_EXECUTABLE_FILE
+  return portableExecutablePath ? path.resolve(portableExecutablePath) : null
+}
+
+function getPortableUpdateChannel(): string | null {
+  const portableExecutablePath = getPortableExecutablePath()
+  if (!portableExecutablePath) {
+    return null
+  }
+
+  return `latest-portable-${process.arch}`
+}
+
+function getDownloadedUpdateExecutablePath(): string | null {
+  const updater = autoUpdater as typeof autoUpdater & AutoUpdaterWithInternals
+  return updater.installerPath ? path.resolve(updater.installerPath) : null
+}
+
+function getPowerShellExecutablePath(): string {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows'
+  return path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+}
+
+function createPortableUpdateScript(currentExePath: string, downloadedExePath: string): string {
+  const tempDir = app.getPath('temp')
+  const scriptPath = path.join(tempDir, `astrbot-portable-update-${process.pid}-${Date.now()}.ps1`)
+  const scriptContent = [
+    'param(',
+    '  [Parameter(Mandatory = $true)][string]$CurrentExe,',
+    '  [Parameter(Mandatory = $true)][string]$DownloadedExe',
+    ')',
+    "$ErrorActionPreference = 'Stop'",
+    '$BackupExe = "$CurrentExe.old"',
+    '$Deadline = (Get-Date).AddMinutes(2)',
+    'while ((Get-Date) -lt $Deadline) {',
+    '  try {',
+    "    $Handle = [System.IO.File]::Open($CurrentExe, 'Open', 'ReadWrite', 'None')",
+    '    $Handle.Dispose()',
+    '    break',
+    '  } catch {',
+    '    Start-Sleep -Milliseconds 500',
+    '  }',
+    '}',
+    'if (-not (Test-Path -LiteralPath $DownloadedExe)) {',
+    '  throw "找不到已下载的便携版更新文件"',
+    '}',
+    'if (Test-Path -LiteralPath $BackupExe) {',
+    '  Remove-Item -LiteralPath $BackupExe -Force -ErrorAction SilentlyContinue',
+    '}',
+    '$NeedRestore = $false',
+    'try {',
+    '  if (Test-Path -LiteralPath $CurrentExe) {',
+    '    Move-Item -LiteralPath $CurrentExe -Destination $BackupExe -Force',
+    '    $NeedRestore = $true',
+    '  }',
+    '  Move-Item -LiteralPath $DownloadedExe -Destination $CurrentExe -Force',
+    '  $NeedRestore = $false',
+    '  if (Test-Path -LiteralPath $BackupExe) {',
+    '    Remove-Item -LiteralPath $BackupExe -Force -ErrorAction SilentlyContinue',
+    '  }',
+    "  Start-Process -FilePath $CurrentExe -ArgumentList '--updated'",
+    '} catch {',
+    '  if ($NeedRestore -and (Test-Path -LiteralPath $BackupExe) -and -not (Test-Path -LiteralPath $CurrentExe)) {',
+    '    Move-Item -LiteralPath $BackupExe -Destination $CurrentExe -Force',
+    '  }',
+    '  throw',
+    '}'
+  ].join('\n')
+
+  fs.writeFileSync(scriptPath, scriptContent, 'utf8')
+  writeLogEntry('info', 'updater', `已生成便携版更新替换脚本: ${scriptPath}`)
+  writeLogEntry('info', 'updater', `便携版当前路径: ${currentExePath}`)
+  writeLogEntry('info', 'updater', `便携版更新包路径: ${downloadedExePath}`)
+  return scriptPath
+}
+
+function installPortableUpdate(): InstallUpdateResult {
+  const currentExePath = getPortableExecutablePath()
+  if (!currentExePath) {
+    return {
+      success: false,
+      message: '未找到当前便携版可执行文件路径'
+    }
+  }
+
+  const downloadedExePath = getDownloadedUpdateExecutablePath()
+  if (!downloadedExePath || !fs.existsSync(downloadedExePath)) {
+    return {
+      success: false,
+      message: '未找到已下载的便携版更新文件'
+    }
+  }
+
+  if (!fs.existsSync(currentExePath)) {
+    return {
+      success: false,
+      message: '当前便携版可执行文件不存在，无法替换更新'
+    }
+  }
+
+  if (path.resolve(currentExePath) === path.resolve(downloadedExePath)) {
+    return {
+      success: false,
+      message: '下载的更新文件路径异常，无法执行便携版替换更新'
+    }
+  }
+
+  const scriptPath = createPortableUpdateScript(currentExePath, downloadedExePath)
+  const powerShellPath = getPowerShellExecutablePath()
+
+  try {
+    const child = spawn(
+      powerShellPath,
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        scriptPath,
+        '-CurrentExe',
+        currentExePath,
+        '-DownloadedExe',
+        downloadedExePath
+      ],
+      {
+        detached: true,
+        stdio: 'ignore'
+      }
+    )
+
+    child.unref()
+    writeLogEntry('info', 'updater', '便携版更新替换脚本已启动，准备退出当前应用')
+    setImmediate(() => {
+      app.quit()
+    })
+
+    return {
+      success: true,
+      message: '正在关闭应用并替换便携版更新'
+    }
+  } catch (error) {
+    const message = extractErrorMessage(error)
+    writeLogEntry('error', 'updater', '启动便携版更新替换脚本失败:', message)
+    return {
+      success: false,
+      message: `启动便携版更新失败: ${message}`
+    }
+  }
+}
+
 function isAutoUpdateSupportedPlatform(): boolean {
   return process.platform === 'win32' || process.platform === 'darwin'
 }
 
 function isAutoUpdateEnabled(): boolean {
-  return app.isPackaged && isAutoUpdateSupportedPlatform() && !isPortableBuild() && hasUpdateConfigFile()
+  return app.isPackaged && isAutoUpdateSupportedPlatform() && hasUpdateConfigFile()
 }
 
 function isAutoUpdateCheckEnabled(): boolean {
@@ -105,19 +271,33 @@ function handleDownloadProgress(progress: ProgressInfo): void {
 async function promptInstallUpdate(info: UpdateInfo): Promise<void> {
   try {
     const focusedWindow = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0] || null
+    const installPromptMessage = isPortableBuild()
+      ? `新版本 ${info.version} 已下载完成`
+      : `新版本 ${info.version} 已下载完成`
+    const installPromptDetail = isPortableBuild()
+      ? '是否现在关闭应用并替换便携版更新？'
+      : '是否现在重启并安装更新？'
+    const confirmButtonText = isPortableBuild() ? '立即替换' : '立即安装'
     const result = await dialog.showMessageBox(focusedWindow, {
       type: 'info',
       title: '发现新版本',
-      message: `新版本 ${info.version} 已下载完成`,
-      detail: '是否现在重启并安装更新？',
-      buttons: ['立即安装', '稍后'],
+      message: installPromptMessage,
+      detail: installPromptDetail,
+      buttons: [confirmButtonText, '稍后'],
       defaultId: 0,
       cancelId: 1
     })
 
     if (result.response === 0) {
       writeLogEntry('info', 'updater', '用户确认立即安装更新')
-      autoUpdater.quitAndInstall()
+      const installResult = quitAndInstallUpdate()
+      if (!installResult.success) {
+        await dialog.showMessageBox(focusedWindow, {
+          type: 'error',
+          title: '更新失败',
+          message: installResult.message
+        })
+      }
     }
   } catch (error) {
     writeLogEntry('error', 'updater', '弹出更新安装确认框失败:', error)
@@ -157,7 +337,9 @@ function setupAutoUpdaterListeners(): void {
   autoUpdater.on('update-downloaded', (info) => {
     setUpdateState({
       status: 'downloaded',
-      message: `新版本 ${info.version} 已下载完成，等待安装`,
+      message: isPortableBuild()
+        ? `新版本 ${info.version} 已下载完成，等待替换`
+        : `新版本 ${info.version} 已下载完成，等待安装`,
       latestVersion: info.version,
       progress: 100,
       releaseDate: info.releaseDate
@@ -180,10 +362,6 @@ function setupAutoUpdaterListeners(): void {
 function getDisabledReason(): string {
   if (!app.isPackaged) {
     return '开发环境不启用自动更新'
-  }
-
-  if (isPortableBuild()) {
-    return '便携版不支持自动更新'
   }
 
   if (!isAutoUpdateSupportedPlatform()) {
@@ -218,8 +396,15 @@ export function initializeAutoUpdater(): void {
     return
   }
 
+  const updater = autoUpdater as typeof autoUpdater & AutoUpdaterWithInternals
+  const portableChannel = getPortableUpdateChannel()
+  if (portableChannel) {
+    updater.channel = portableChannel
+    writeLogEntry('info', 'updater', `便携版更新通道已切换为 ${portableChannel}`)
+  }
+
   autoUpdater.autoDownload = true
-  autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.autoInstallOnAppQuit = !isPortableBuild()
   autoUpdater.allowPrerelease = app.getVersion().includes('-')
   autoUpdater.allowDowngrade = false
 
@@ -233,7 +418,7 @@ export function initializeAutoUpdater(): void {
   writeLogEntry(
     'info',
     'updater',
-    `自动更新已启用，平台=${process.platform}，当前版本=${app.getVersion()}，allowPrerelease=${autoUpdater.allowPrerelease}`
+    `自动更新已启用，平台=${process.platform}，当前版本=${app.getVersion()}，channel=${updater.channel || 'latest'}，allowPrerelease=${autoUpdater.allowPrerelease}`
   )
 
   if (!isAutoUpdateCheckEnabled()) {
@@ -339,6 +524,11 @@ export function quitAndInstallUpdate(): { success: boolean; message: string } {
       success: false,
       message: '当前没有可安装的已下载更新'
     }
+  }
+
+  if (isPortableBuild()) {
+    writeLogEntry('info', 'updater', '收到便携版更新安装请求，准备关闭应用并替换更新')
+    return installPortableUpdate()
   }
 
   writeLogEntry('info', 'updater', '收到手动安装更新请求，准备重启安装')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrbot-live2d-desktop",
-  "version": "1.1.0-beta.18",
+  "version": "1.1.0-beta.19",
   "description": "AstrBot Live2D 桌面应用",
   "main": "dist-electron/main.js",
   "type": "module",
@@ -92,9 +92,9 @@
     "rebuild:electron": "electron-rebuild -f -w extract-file-icon,node-window-manager,better-sqlite3",
     "build:prepare": "pnpm run typecheck && pnpm exec vite build",
     "build:prepare:fast": "pnpm exec vite build",
-    "pack": "pnpm exec electron-builder --publish never",
+    "pack": "pnpm exec electron-builder --publish never && node scripts/generate-portable-update-metadata.mjs",
     "pack:dir": "pnpm exec electron-builder --dir --publish never",
-    "pack:win": "pnpm exec electron-builder --win --publish never",
+    "pack:win": "pnpm exec electron-builder --win --publish never && node scripts/generate-portable-update-metadata.mjs",
     "pack:mac": "pnpm exec electron-builder --mac --publish never",
     "pack:linux": "pnpm exec electron-builder --linux --publish never",
     "pack:linux:core": "pnpm exec electron-builder --linux AppImage deb --publish never",
@@ -245,6 +245,7 @@
       ]
     },
     "nsis": {
+      "artifactName": "astrbot-live2d-desktop-v${version}-win-${arch}.${ext}",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "allowElevation": true,
@@ -256,6 +257,9 @@
       "uninstallerIcon": "resources/icon.ico",
       "runAfterFinish": true,
       "packElevateHelper": true
+    },
+    "portable": {
+      "artifactName": "astrbot-live2d-desktop-v${version}-portable-${arch}.${ext}"
     },
     "mac": {
       "icon": "icon.icns",

--- a/scripts/generate-portable-update-metadata.mjs
+++ b/scripts/generate-portable-update-metadata.mjs
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const projectRoot = path.resolve(__dirname, '..')
+const releaseDir = path.join(projectRoot, 'release')
+const packageJsonPath = path.join(projectRoot, 'package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+const cliArgs = process.argv.slice(2)
+const archArgFromOption = cliArgs
+  .find((arg) => arg.startsWith('--arch='))
+  ?.slice('--arch='.length)
+const archArgFromFlag = cliArgs.find((arg) => arg === '--x64' || arg === '--arm64')?.slice(2)
+const archArg = archArgFromOption || archArgFromFlag || null
+
+const escapedVersion = packageJson.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const portablePattern = new RegExp(
+  `^astrbot-live2d-desktop-v${escapedVersion}-portable-(x64|arm64)\\.exe$`,
+  'i'
+)
+
+function toSha512(filePath) {
+  const hash = createHash('sha512')
+  hash.update(fs.readFileSync(filePath))
+  return hash.digest('base64')
+}
+
+function buildMetadata(fileName, filePath) {
+  const stat = fs.statSync(filePath)
+  const sha512 = toSha512(filePath)
+  return [
+    `version: ${packageJson.version}`,
+    'files:',
+    `  - url: ${fileName}`,
+    `    sha512: ${sha512}`,
+    `    size: ${stat.size}`,
+    `path: ${fileName}`,
+    `sha512: ${sha512}`,
+    `releaseDate: '${stat.mtime.toISOString()}'`,
+    ''
+  ].join('\n')
+}
+
+if (!fs.existsSync(releaseDir)) {
+  console.log('[META] 未找到 release 目录，跳过便携版更新元数据生成')
+  process.exit(0)
+}
+
+if (!archArg && process.platform !== 'win32') {
+  console.log('[META] 当前不是 Windows 打包环境，跳过便携版更新元数据生成')
+  process.exit(0)
+}
+
+const portableArtifacts = fs
+  .readdirSync(releaseDir, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && portablePattern.test(entry.name))
+  .map((entry) => entry.name)
+  .filter((fileName) => {
+    if (!archArg) {
+      return true
+    }
+    return fileName.toLowerCase().endsWith(`portable-${archArg.toLowerCase()}.exe`)
+  })
+
+if (portableArtifacts.length === 0) {
+  console.log('[META] 未找到匹配的便携版产物，跳过便携版更新元数据生成')
+  process.exit(0)
+}
+
+for (const fileName of portableArtifacts) {
+  const match = fileName.match(portablePattern)
+  if (!match) {
+    continue
+  }
+
+  const arch = match[1].toLowerCase()
+  const filePath = path.join(releaseDir, fileName)
+  const metadataPath = path.join(releaseDir, `latest-portable-${arch}.yml`)
+  fs.writeFileSync(metadataPath, buildMetadata(fileName, filePath), 'utf8')
+  console.log(`[META] 已生成 ${path.basename(metadataPath)} -> ${fileName}`)
+}


### PR DESCRIPTION
## 变更摘要
- 为 Windows 安装版与便携版分别设置独立 artifactName，避免产物互相覆盖
- 新增便携版更新元数据生成脚本，并在 CI 中上传 latest-portable-x64.yml / latest-portable-arm64.yml
- 支持 Windows 便携版通过独立更新通道下载更新，并在退出后替换当前 portable exe

## 验证
- pnpm run typecheck
- pnpm run build:prepare
- pnpm run pack:win -- --x64

## Summary by Sourcery

Add dedicated Windows portable build update channel and metadata to prevent artifacts clashing and enable in-place portable updates.

New Features:
- Enable automatic update support for Windows portable builds via a dedicated portable update channel and interactive update flow.
- Introduce a script to generate portable build update metadata files (latest-portable-*.yml) during packaging and CI for each Windows architecture.

Bug Fixes:
- Allow Windows installer and portable artifacts to coexist without overwriting each other by using separate artifact names.

Enhancements:
- Differentiate installer and portable artifacts with distinct artifactName patterns to avoid output conflicts.
- Log additional updater details including selected update channel and portable update flow information.

Build:
- Hook portable update metadata generation into local packaging commands for Windows builds.

CI:
- Update GitHub Actions workflow to generate and upload portable update metadata artifacts for Windows builds.