### PR TITLE
fix: 统一数据目录并修复 astrbot-model 协议加载

### DIFF
--- a/electron/database/schema.ts
+++ b/electron/database/schema.ts
@@ -6,11 +6,16 @@ import { createRequire } from 'module'
 import { normalizeMessageDirection, type MessageDirection } from './messageDirection'
 import { buildMessageKeywordSearchCondition } from './messageSearch'
 import { resolveBetterSqliteNativeBindingPath } from './nativeBinding'
+import { USER_CONFIG_KEYS } from '../../src/shared/metadata'
 import { getAppDataPath } from '../utils/appPaths'
 
 let db: Database.Database | null = null
 const require = createRequire(import.meta.url)
 const CURRENT_DB_VERSION = 2
+const USER_PROFILE_CONFIG_KEYS = {
+  userId: USER_CONFIG_KEYS.userId,
+  userName: USER_CONFIG_KEYS.userName,
+} as const
 
 function setDatabaseVersion(database: Database.Database, version: number): void {
   database.pragma(`user_version = ${Math.max(0, Math.floor(version))}`)
@@ -550,11 +555,11 @@ export function setUserConfig(key: string, value: string): void {
  * user_id 是设备级标识，首次生成后永不变更，与用户名无关
  */
 export function getUserId(): string {
-  let userId = getUserConfig('user_id')
+  let userId = getUserConfig(USER_PROFILE_CONFIG_KEYS.userId)
   if (!userId) {
     // 生成设备级 UUID，确保跨设备唯一性
     userId = crypto.randomUUID()
-    setUserConfig('user_id', userId)
+    setUserConfig(USER_PROFILE_CONFIG_KEYS.userId, userId)
   }
   return userId
 }
@@ -563,7 +568,7 @@ export function getUserId(): string {
  * 获取用户名称
  */
 export function getUserName(): string | null {
-  const userName = getUserConfig('user_name')
+  const userName = getUserConfig(USER_PROFILE_CONFIG_KEYS.userName)
   // 如果用户名为空或无效，返回 null（触发欢迎窗口）
   if (!userName || userName.trim() === '') {
     return null
@@ -575,7 +580,7 @@ export function getUserName(): string | null {
  * 设置用户名称
  */
 export function setUserName(name: string): void {
-  setUserConfig('user_name', name)
+  setUserConfig(USER_PROFILE_CONFIG_KEYS.userName, name)
 }
 
 /**

--- a/electron/database/schema.ts
+++ b/electron/database/schema.ts
@@ -1,5 +1,4 @@
 import Database from 'better-sqlite3'
-import { app } from 'electron'
 import path from 'path'
 import crypto from 'crypto'
 import fs from 'fs'
@@ -7,6 +6,7 @@ import { createRequire } from 'module'
 import { normalizeMessageDirection, type MessageDirection } from './messageDirection'
 import { buildMessageKeywordSearchCondition } from './messageSearch'
 import { resolveBetterSqliteNativeBindingPath } from './nativeBinding'
+import { getAppDataPath } from '../utils/appPaths'
 
 let db: Database.Database | null = null
 const require = createRequire(import.meta.url)
@@ -169,24 +169,8 @@ function ensureMessageSearchIndex(database: Database.Database): void {
 export function initDatabase(): Database.Database {
   if (db) return db
 
-  // 便携版判断:如果存在 PORTABLE_EXECUTABLE_DIR 环境变量,使用应用程序目录
-  let dbPath: string
-  const exePath = path.dirname(app.getPath('exe'))
-  const portableMarker = path.join(exePath, 'portable.txt')
-
-  if (process.env.PORTABLE_EXECUTABLE_DIR || fs.existsSync(portableMarker)) {
-    // 便携版:数据存储在应用程序目录下的 data 文件夹
-    const portableDataDir = path.join(exePath, 'data')
-    if (!fs.existsSync(portableDataDir)) {
-      fs.mkdirSync(portableDataDir, { recursive: true })
-    }
-    dbPath = path.join(portableDataDir, 'history.db')
-    console.log('[数据库] 便携模式,使用路径:', dbPath)
-  } else {
-    // 安装版:使用标准 userData 路径
-    dbPath = path.join(app.getPath('userData'), 'history.db')
-    console.log('[数据库] 标准模式,使用路径:', dbPath)
-  }
+  const dbPath = path.join(getAppDataPath(), 'history.db')
+  console.log('[数据库] 使用路径:', dbPath)
 
   const betterSqlitePackageJsonPath = require.resolve('better-sqlite3/package.json')
   const nativeBindingPath = resolveBetterSqliteNativeBindingPath(betterSqlitePackageJsonPath)

--- a/electron/ipc/model.ts
+++ b/electron/ipc/model.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url'
 import { formatCubismAssetIssues, validateCubismModelAssets } from '../utils/cubismAssetManifest'
+import { getAppDataPath } from '../utils/appPaths'
 
 /**
  * 获取模型存储目录
@@ -13,7 +14,7 @@ function getModelsDir(): string {
   if (isDev) {
     return path.join(process.cwd(), 'public', 'models')
   }
-  return path.join(app.getPath('userData'), 'models')
+  return path.join(getAppDataPath(), 'models')
 }
 
 function toPosixPath(p: string): string {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -88,8 +88,14 @@ async function initialize() {
     )
   }
   if (migrationResult.errors.length > 0) {
+    const displayedErrors = migrationResult.errors.slice(0, 5)
+    const remainingErrorCount = migrationResult.errors.length - displayedErrors.length
+    const truncatedSuffix = remainingErrorCount > 0
+      ? ` | 另外 ${remainingErrorCount} 个问题未展开`
+      : ''
+
     console.warn(
-      `[主进程] 数据迁移存在 ${migrationResult.errors.length} 个问题: ${migrationResult.errors.slice(0, 5).join(' | ')}`
+      `[主进程] 数据迁移存在 ${migrationResult.errors.length} 个问题: ${displayedErrors.join(' | ')}${truncatedSuffix}`
     )
   }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,8 @@ import { cleanupShortcuts } from './ipc/shortcut'
 import { getDesktopBehaviorCoordinator } from './desktopBehavior/coordinator'
 import { checkCubismCoreExists, showDownloadDialog, downloadWithProgress, registerCubismCoreProtocol } from './utils/downloadCubismCore'
 import { registerHistoryResourceProtocol } from './utils/historyResourceProtocol'
+import { migrateLegacyAppDataIfNeeded } from './utils/appDataMigration'
+import { configureElectronDataPath } from './utils/appPaths'
 import { initializeMainLogger, installMainProcessErrorHandlers, shutdownMainLogger } from './utils/logger'
 import { initializeAutoUpdater } from './utils/updater'
 import './ipc/connection'
@@ -35,11 +37,16 @@ if (process.platform === 'win32') {
 // 启用硬件加速以获得更好的性能
 // 注意：Windows 透明窗口在新版 Electron 中已支持硬件加速
 
+const appDataContext = configureElectronDataPath()
+
 // 全局 WebSocket 客户端实例
 export let bridgeClient: L2DBridgeClient | null = null
 
 initializeMainLogger()
 installMainProcessErrorHandlers()
+console.log(
+  `[主进程] 数据目录模式=${appDataContext.mode} 原始路径=${appDataContext.originalUserDataPath} 当前路径=${appDataContext.resolvedUserDataPath}`
+)
 
 // 锁屏前的状态，用于解锁后恢复
 let isBackgroundPaused = false
@@ -74,6 +81,18 @@ function resumeBackgroundActivities(reason: string): void {
  * 应用程序初始化
  */
 async function initialize() {
+  const migrationResult = await migrateLegacyAppDataIfNeeded()
+  if (migrationResult.copiedEntries.length > 0) {
+    console.log(
+      `[主进程] 已复制 ${migrationResult.copiedEntries.length} 个旧数据条目到当前数据目录`
+    )
+  }
+  if (migrationResult.errors.length > 0) {
+    console.warn(
+      `[主进程] 数据迁移存在 ${migrationResult.errors.length} 个问题: ${migrationResult.errors.slice(0, 5).join(' | ')}`
+    )
+  }
+
   // 初始化数据库
   try {
     initDatabase()

--- a/electron/utils/appDataMigration.ts
+++ b/electron/utils/appDataMigration.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getAppDataPathContext } from './appPaths'
+
+export const APP_DATA_MIGRATION_MARKER_FILE = '.app-data-migration-v1.json'
+export const APP_DATA_MIGRATION_ENTRIES = [
+  'history.db',
+  'history.db-shm',
+  'history.db-wal',
+  'models',
+  'logs',
+  'lib',
+  'window-watcher-config.json',
+  'Local Storage',
+  'Session Storage',
+  'IndexedDB',
+  'WebStorage',
+  'Preferences',
+  'Cookies',
+  'Cookies-journal',
+  path.join('Network', 'Cookies'),
+  path.join('Network', 'Cookies-journal'),
+] as const
+
+export interface AppDataMigrationResult {
+  attempted: boolean
+  sourceRoot: string
+  targetRoot: string
+  markerPath: string
+  copiedEntries: string[]
+  errors: string[]
+  skippedReason?: 'not-portable' | 'same-path' | 'marker-exists' | 'source-missing'
+}
+
+interface MigrateAppDataOptions {
+  sourceRoot: string
+  targetRoot: string
+  markerFileName?: string
+  entries?: readonly string[]
+}
+
+interface MigrationMarkerPayload {
+  version: 1
+  sourceRoot: string
+  targetRoot: string
+  migratedAt: string
+  copiedEntries: string[]
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function copyMissingFile(sourcePath: string, targetPath: string): Promise<boolean> {
+  if (await pathExists(targetPath)) {
+    return false
+  }
+
+  await fs.mkdir(path.dirname(targetPath), { recursive: true })
+  await fs.copyFile(sourcePath, targetPath)
+  return true
+}
+
+async function copyMissingDirectory(
+  sourcePath: string,
+  targetPath: string,
+  rootTarget: string,
+  copiedEntries: string[],
+): Promise<void> {
+  await fs.mkdir(targetPath, { recursive: true })
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const nextSource = path.join(sourcePath, entry.name)
+    const nextTarget = path.join(targetPath, entry.name)
+
+    if (entry.isDirectory()) {
+      await copyMissingDirectory(nextSource, nextTarget, rootTarget, copiedEntries)
+      continue
+    }
+
+    if (!entry.isFile()) {
+      continue
+    }
+
+    if (await copyMissingFile(nextSource, nextTarget)) {
+      copiedEntries.push(path.relative(rootTarget, nextTarget))
+    }
+  }
+}
+
+function createBaseResult(
+  sourceRoot: string,
+  targetRoot: string,
+  markerPath: string,
+): AppDataMigrationResult {
+  return {
+    attempted: false,
+    sourceRoot,
+    targetRoot,
+    markerPath,
+    copiedEntries: [],
+    errors: [],
+  }
+}
+
+async function writeMigrationMarker(markerPath: string, payload: MigrationMarkerPayload): Promise<void> {
+  await fs.mkdir(path.dirname(markerPath), { recursive: true })
+  await fs.writeFile(markerPath, JSON.stringify(payload, null, 2), 'utf8')
+}
+
+export async function migrateAppDataByCopy(options: MigrateAppDataOptions): Promise<AppDataMigrationResult> {
+  const sourceRoot = path.resolve(options.sourceRoot)
+  const targetRoot = path.resolve(options.targetRoot)
+  const markerPath = path.join(targetRoot, options.markerFileName ?? APP_DATA_MIGRATION_MARKER_FILE)
+  const result = createBaseResult(sourceRoot, targetRoot, markerPath)
+
+  if (sourceRoot === targetRoot) {
+    result.skippedReason = 'same-path'
+    return result
+  }
+
+  if (!await pathExists(sourceRoot)) {
+    result.skippedReason = 'source-missing'
+    return result
+  }
+
+  if (await pathExists(markerPath)) {
+    result.skippedReason = 'marker-exists'
+    return result
+  }
+
+  const entries = options.entries ?? APP_DATA_MIGRATION_ENTRIES
+  await fs.mkdir(targetRoot, { recursive: true })
+  result.attempted = true
+
+  for (const relativeEntry of entries) {
+    const sourcePath = path.join(sourceRoot, relativeEntry)
+    if (!await pathExists(sourcePath)) {
+      continue
+    }
+
+    const targetPath = path.join(targetRoot, relativeEntry)
+
+    try {
+      const stat = await fs.stat(sourcePath)
+      if (stat.isDirectory()) {
+        await copyMissingDirectory(sourcePath, targetPath, targetRoot, result.copiedEntries)
+        continue
+      }
+
+      if (stat.isFile() && await copyMissingFile(sourcePath, targetPath)) {
+        result.copiedEntries.push(relativeEntry)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      result.errors.push(`${relativeEntry}: ${message}`)
+    }
+  }
+
+  if (result.errors.length === 0) {
+    await writeMigrationMarker(markerPath, {
+      version: 1,
+      sourceRoot,
+      targetRoot,
+      migratedAt: new Date().toISOString(),
+      copiedEntries: result.copiedEntries,
+    })
+  }
+
+  return result
+}
+
+export async function migrateLegacyAppDataIfNeeded(): Promise<AppDataMigrationResult> {
+  const context = getAppDataPathContext()
+  const markerPath = path.join(context.resolvedUserDataPath, APP_DATA_MIGRATION_MARKER_FILE)
+
+  if (!context.isPortable) {
+    return {
+      attempted: false,
+      sourceRoot: context.originalUserDataPath,
+      targetRoot: context.resolvedUserDataPath,
+      markerPath,
+      copiedEntries: [],
+      errors: [],
+      skippedReason: 'not-portable',
+    }
+  }
+
+  return migrateAppDataByCopy({
+    sourceRoot: context.originalUserDataPath,
+    targetRoot: context.resolvedUserDataPath,
+    markerFileName: APP_DATA_MIGRATION_MARKER_FILE,
+  })
+}

--- a/electron/utils/appPaths.ts
+++ b/electron/utils/appPaths.ts
@@ -2,28 +2,110 @@ import { app } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 
-/**
- * 便携模式检测：PORTABLE_EXECUTABLE_DIR 环境变量（electron-builder portable）
- * 或 exe 同级存在 portable.txt 标记文件
- */
-export function isPortableMode(): boolean {
-  const exeDir = path.dirname(app.getPath('exe'))
-  return Boolean(
-    process.env.PORTABLE_EXECUTABLE_DIR ||
-    fs.existsSync(path.join(exeDir, 'portable.txt'))
-  )
+export type AppStorageMode = 'development' | 'installed' | 'portable'
+
+export interface AppDataPathContext {
+  mode: AppStorageMode
+  isPortable: boolean
+  portableBaseDir: string | null
+  originalUserDataPath: string
+  resolvedUserDataPath: string
 }
 
-/**
- * 获取应用数据根目录
- * 安装版：app.getPath('userData')
- * 便携版：exe 同级的 data/ 文件夹
- */
-export function getAppDataPath(): string {
-  if (isPortableMode()) {
-    const dataDir = path.join(path.dirname(app.getPath('exe')), 'data')
-    fs.mkdirSync(dataDir, { recursive: true })
-    return dataDir
+export interface ResolveAppDataPathContextOptions {
+  isPackaged: boolean
+  originalUserDataPath: string
+  exePath: string
+  portableExecutableDir?: string | null
+  hasPortableMarker?: boolean
+}
+
+let originalUserDataPathCache: string | null = null
+let cachedContext: AppDataPathContext | null = null
+let configured = false
+
+function normalizeOptionalPath(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null
   }
-  return app.getPath('userData')
+
+  const trimmed = value.trim()
+  return trimmed ? path.resolve(trimmed) : null
+}
+
+function captureOriginalUserDataPath(): string {
+  if (!originalUserDataPathCache) {
+    originalUserDataPathCache = path.resolve(app.getPath('userData'))
+  }
+
+  return originalUserDataPathCache
+}
+
+export function resolveAppDataPathContext(options: ResolveAppDataPathContextOptions): AppDataPathContext {
+  const originalUserDataPath = path.resolve(options.originalUserDataPath)
+  const portableExecutableDir = normalizeOptionalPath(options.portableExecutableDir)
+  const portableBaseDir = options.isPackaged
+    ? (portableExecutableDir || (options.hasPortableMarker ? path.dirname(path.resolve(options.exePath)) : null))
+    : null
+  const mode: AppStorageMode = !options.isPackaged
+    ? 'development'
+    : (portableBaseDir ? 'portable' : 'installed')
+
+  return {
+    mode,
+    isPortable: mode === 'portable',
+    portableBaseDir,
+    originalUserDataPath,
+    resolvedUserDataPath: mode === 'portable'
+      ? path.join(portableBaseDir as string, 'data')
+      : originalUserDataPath,
+  }
+}
+
+export function getAppDataPathContext(): AppDataPathContext {
+  if (cachedContext) {
+    return cachedContext
+  }
+
+  const exePath = app.getPath('exe')
+  const exeDir = path.dirname(exePath)
+  cachedContext = resolveAppDataPathContext({
+    isPackaged: app.isPackaged,
+    originalUserDataPath: captureOriginalUserDataPath(),
+    exePath,
+    portableExecutableDir: process.env.PORTABLE_EXECUTABLE_DIR,
+    hasPortableMarker: fs.existsSync(path.join(exeDir, 'portable.txt')),
+  })
+
+  return cachedContext
+}
+
+export function configureElectronDataPath(): AppDataPathContext {
+  const context = getAppDataPathContext()
+  if (configured || !context.isPortable) {
+    return context
+  }
+
+  fs.mkdirSync(context.resolvedUserDataPath, { recursive: true })
+  app.setPath('userData', context.resolvedUserDataPath)
+  app.setPath('sessionData', context.resolvedUserDataPath)
+  configured = true
+
+  return context
+}
+
+export function isPortableMode(): boolean {
+  return getAppDataPathContext().isPortable
+}
+
+export function getOriginalUserDataPath(): string {
+  return getAppDataPathContext().originalUserDataPath
+}
+
+export function getResolvedUserDataPath(): string {
+  return getAppDataPathContext().resolvedUserDataPath
+}
+
+export function getAppDataPath(): string {
+  return getResolvedUserDataPath()
 }

--- a/electron/utils/appPaths.ts
+++ b/electron/utils/appPaths.ts
@@ -1,0 +1,29 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * 便携模式检测：PORTABLE_EXECUTABLE_DIR 环境变量（electron-builder portable）
+ * 或 exe 同级存在 portable.txt 标记文件
+ */
+export function isPortableMode(): boolean {
+  const exeDir = path.dirname(app.getPath('exe'))
+  return Boolean(
+    process.env.PORTABLE_EXECUTABLE_DIR ||
+    fs.existsSync(path.join(exeDir, 'portable.txt'))
+  )
+}
+
+/**
+ * 获取应用数据根目录
+ * 安装版：app.getPath('userData')
+ * 便携版：exe 同级的 data/ 文件夹
+ */
+export function getAppDataPath(): string {
+  if (isPortableMode()) {
+    const dataDir = path.join(path.dirname(app.getPath('exe')), 'data')
+    fs.mkdirSync(dataDir, { recursive: true })
+    return dataDir
+  }
+  return app.getPath('userData')
+}

--- a/electron/utils/downloadCubismCore.ts
+++ b/electron/utils/downloadCubismCore.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url'
 import { app, dialog, net, protocol } from 'electron'
+import { getAppDataPath } from './appPaths'
 
 const CUBISM_PROTOCOL_SCHEME = 'cubism'
 
@@ -70,17 +71,6 @@ protocol.registerSchemesAsPrivileged([
 
 let cubismProtocolRegistered = false
 
-function isPortableMode(): boolean {
-  const exePath = path.dirname(app.getPath('exe'))
-  const portableMarker = path.join(exePath, 'portable.txt')
-  return Boolean(process.env.PORTABLE_EXECUTABLE_DIR || fs.existsSync(portableMarker))
-}
-
-function getPortableDataDir(): string {
-  const exePath = path.dirname(app.getPath('exe'))
-  return path.join(exePath, 'data')
-}
-
 function getLegacyPackagedCubismCorePath(): string | null {
   if (!app.isPackaged) {
     return null
@@ -129,11 +119,7 @@ export function getCubismCorePath(): string {
     return path.join(process.cwd(), 'public', 'lib', getCubismCoreFilename())
   }
 
-  if (isPortableMode()) {
-    return path.join(getPortableDataDir(), 'lib', getCubismCoreFilename())
-  }
-
-  return path.join(app.getPath('userData'), 'lib', getCubismCoreFilename())
+  return path.join(getAppDataPath(), 'lib', getCubismCoreFilename())
 }
 
 export function getCubismCoreProtocolUrl(): string {

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -1,7 +1,7 @@
-import { app } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
+import { getAppDataPath } from './appPaths'
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 export type LogOutputLevel = 'debug' | 'info'
@@ -50,7 +50,7 @@ function writeInternalError(message: string): void {
 
 function resolveUserDataPath(): string {
   try {
-    return app.getPath('userData')
+    return getAppDataPath()
   } catch {
     return path.join(process.cwd(), 'userData')
   }

--- a/electron/utils/windowWatcherConfig.ts
+++ b/electron/utils/windowWatcherConfig.ts
@@ -4,9 +4,9 @@
  * 定义窗口监听器的所有配置项，支持用户自定义
  */
 
-import { app } from 'electron'
 import fs from 'fs/promises'
 import path from 'path'
+import { getAppDataPath } from './appPaths'
 
 /**
  * 窗口事件类型
@@ -214,7 +214,7 @@ export function getMergedIgnoreRules(userConfig: WindowWatcherConfig): {
  * 配置文件路径
  */
 function getConfigPath(): string {
-  return path.join(app.getPath('userData'), 'window-watcher-config.json')
+  return path.join(getAppDataPath(), 'window-watcher-config.json')
 }
 
 /**

--- a/main.html
+++ b/main.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource:; connect-src 'self' http: https: ws: wss: file: history-resource:; media-src 'self' data: http: https: blob: file: history-resource:" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource: astrbot-model:; connect-src 'self' http: https: ws: wss: file: history-resource: astrbot-model:; media-src 'self' data: http: https: blob: file: history-resource: astrbot-model:" />
     <title>AstrBot Live2D Desktop</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
         }
       },
       "userConfig": {
+        "userId": "user_id",
+        "userName": "user_name",
         "autoUpdateEnabled": "app_auto_update_enabled",
         "screenshotDefaultTarget": "desktop_capture_default_target",
         "screenshotQuality": "desktop_capture_quality",

--- a/settings.html
+++ b/settings.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource:; connect-src 'self' http: https: ws: wss: file: history-resource:; media-src 'self' data: http: https: blob: file: history-resource:" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource: astrbot-model:; connect-src 'self' http: https: ws: wss: file: history-resource: astrbot-model:; media-src 'self' data: http: https: blob: file: history-resource: astrbot-model:" />
     <title>设置 - AstrBot Live2D Desktop</title>
   </head>
   <body>

--- a/tests/appDataMigration.test.ts
+++ b/tests/appDataMigration.test.ts
@@ -1,0 +1,79 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  APP_DATA_MIGRATION_MARKER_FILE,
+  migrateAppDataByCopy,
+} from '../electron/utils/appDataMigration'
+
+const tempRoots: string[] = []
+
+function createTempDir(prefix: string): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  tempRoots.push(tempDir)
+  return tempDir
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const targetPath = path.join(root, relativePath)
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+  fs.writeFileSync(targetPath, content, 'utf8')
+}
+
+function readFile(root: string, relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+describe('appDataMigration', () => {
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      const target = tempRoots.pop()
+      if (target && fs.existsSync(target)) {
+        fs.rmSync(target, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('copies missing data entries without overwriting existing target files', async () => {
+    const sourceRoot = createTempDir('astrbot-migration-source-')
+    const targetRoot = createTempDir('astrbot-migration-target-')
+
+    writeFile(sourceRoot, 'history.db', 'legacy-db')
+    writeFile(sourceRoot, 'models/Haru/model3.json', 'legacy-model')
+    writeFile(sourceRoot, 'Local Storage/leveldb/000003.log', 'legacy-local-storage')
+    writeFile(sourceRoot, 'Cache/cache.bin', 'should-not-copy')
+
+    writeFile(targetRoot, 'history.db', 'current-db')
+    writeFile(targetRoot, 'models/Haru/current.txt', 'current-model')
+
+    const result = await migrateAppDataByCopy({ sourceRoot, targetRoot })
+
+    expect(result.attempted).toBe(true)
+    expect(result.errors).toEqual([])
+    expect(readFile(targetRoot, 'history.db')).toBe('current-db')
+    expect(readFile(targetRoot, 'models/Haru/model3.json')).toBe('legacy-model')
+    expect(readFile(targetRoot, 'models/Haru/current.txt')).toBe('current-model')
+    expect(readFile(targetRoot, 'Local Storage/leveldb/000003.log')).toBe('legacy-local-storage')
+    expect(fs.existsSync(path.join(targetRoot, 'Cache', 'cache.bin'))).toBe(false)
+    expect(fs.existsSync(path.join(targetRoot, APP_DATA_MIGRATION_MARKER_FILE))).toBe(true)
+  })
+
+  it('skips repeated migration once the marker file exists', async () => {
+    const sourceRoot = createTempDir('astrbot-migration-source-')
+    const targetRoot = createTempDir('astrbot-migration-target-')
+
+    writeFile(sourceRoot, 'logs/app.log', 'legacy-log')
+
+    const firstRun = await migrateAppDataByCopy({ sourceRoot, targetRoot })
+    expect(firstRun.attempted).toBe(true)
+    expect(readFile(targetRoot, 'logs/app.log')).toBe('legacy-log')
+
+    writeFile(sourceRoot, 'logs/new.log', 'late-log')
+
+    const secondRun = await migrateAppDataByCopy({ sourceRoot, targetRoot })
+    expect(secondRun.attempted).toBe(false)
+    expect(secondRun.skippedReason).toBe('marker-exists')
+    expect(fs.existsSync(path.join(targetRoot, 'logs', 'new.log'))).toBe(false)
+  })
+})

--- a/tests/appDataMigration.test.ts
+++ b/tests/appDataMigration.test.ts
@@ -1,7 +1,32 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { failingCopySources } = vi.hoisted(() => ({
+  failingCopySources: new Set<string>(),
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  const mockedFs = {
+    ...actual,
+    copyFile: async (...args: Parameters<typeof actual.copyFile>) => {
+      const [sourcePath] = args
+      if (failingCopySources.has(sourcePath)) {
+        throw new Error('simulated copy failure')
+      }
+
+      return actual.copyFile(...args)
+    },
+  }
+
+  return {
+    ...mockedFs,
+    default: mockedFs,
+  }
+})
+
 import {
   APP_DATA_MIGRATION_MARKER_FILE,
   migrateAppDataByCopy,
@@ -27,6 +52,8 @@ function readFile(root: string, relativePath: string): string {
 
 describe('appDataMigration', () => {
   afterEach(() => {
+    failingCopySources.clear()
+
     while (tempRoots.length > 0) {
       const target = tempRoots.pop()
       if (target && fs.existsSync(target)) {
@@ -75,5 +102,21 @@ describe('appDataMigration', () => {
     expect(secondRun.attempted).toBe(false)
     expect(secondRun.skippedReason).toBe('marker-exists')
     expect(fs.existsSync(path.join(targetRoot, 'logs', 'new.log'))).toBe(false)
+  })
+
+  it('does not write the migration marker when copying fails', async () => {
+    const sourceRoot = createTempDir('astrbot-migration-error-source-')
+    const targetRoot = createTempDir('astrbot-migration-error-target-')
+
+    writeFile(sourceRoot, 'logs/app.log', 'legacy-log')
+    failingCopySources.add(path.join(sourceRoot, 'logs', 'app.log'))
+
+    const result = await migrateAppDataByCopy({ sourceRoot, targetRoot })
+
+    expect(result.attempted).toBe(true)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0]).toContain('logs')
+    expect(result.copiedEntries).toEqual([])
+    expect(fs.existsSync(path.join(targetRoot, APP_DATA_MIGRATION_MARKER_FILE))).toBe(false)
   })
 })

--- a/tests/appPaths.test.ts
+++ b/tests/appPaths.test.ts
@@ -1,0 +1,50 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import { resolveAppDataPathContext } from '../electron/utils/appPaths'
+
+describe('appPaths', () => {
+  it('prefers PORTABLE_EXECUTABLE_DIR over exe sibling marker for portable builds', () => {
+    const context = resolveAppDataPathContext({
+      isPackaged: true,
+      originalUserDataPath: 'C:\\Users\\tester\\AppData\\Roaming\\astrbot-live2d-desktop',
+      exePath: 'D:\\portable\\AstrBot Live2D Desktop.exe',
+      portableExecutableDir: 'E:\\AstrBotPortable',
+      hasPortableMarker: true,
+    })
+
+    expect(context.mode).toBe('portable')
+    expect(context.portableBaseDir).toBe(path.resolve('E:\\AstrBotPortable'))
+    expect(context.resolvedUserDataPath).toBe(path.join(path.resolve('E:\\AstrBotPortable'), 'data'))
+  })
+
+  it('keeps the default userData path for installed builds', () => {
+    const originalUserDataPath = path.resolve('C:\\Users\\tester\\AppData\\Roaming\\astrbot-live2d-desktop')
+    const context = resolveAppDataPathContext({
+      isPackaged: true,
+      originalUserDataPath,
+      exePath: 'C:\\Program Files\\AstrBot Live2D Desktop\\AstrBot Live2D Desktop.exe',
+      portableExecutableDir: '',
+      hasPortableMarker: false,
+    })
+
+    expect(context.mode).toBe('installed')
+    expect(context.isPortable).toBe(false)
+    expect(context.resolvedUserDataPath).toBe(originalUserDataPath)
+  })
+
+  it('keeps the default userData path in development mode', () => {
+    const originalUserDataPath = path.resolve('D:\\dev-user-data')
+    const context = resolveAppDataPathContext({
+      isPackaged: false,
+      originalUserDataPath,
+      exePath: 'D:\\repo\\node_modules\\electron\\dist\\electron.exe',
+      portableExecutableDir: 'E:\\ShouldBeIgnored',
+      hasPortableMarker: true,
+    })
+
+    expect(context.mode).toBe('development')
+    expect(context.isPortable).toBe(false)
+    expect(context.portableBaseDir).toBeNull()
+    expect(context.resolvedUserDataPath).toBe(originalUserDataPath)
+  })
+})

--- a/tests/htmlCsp.test.ts
+++ b/tests/htmlCsp.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const htmlFiles = [
+  'main.html',
+  'settings.html',
+  'welcome.html',
+] as const
+
+function readHtml(fileName: string): string {
+  return fs.readFileSync(path.join(process.cwd(), fileName), 'utf8')
+}
+
+describe('htmlCsp', () => {
+  it('allows astrbot-model protocol for connect img and media sources', () => {
+    for (const fileName of htmlFiles) {
+      const html = readHtml(fileName)
+      expect(html).toContain("img-src 'self' data: http: https: blob: file: history-resource: astrbot-model:")
+      expect(html).toContain("connect-src 'self' http: https: ws: wss: file: history-resource: astrbot-model:")
+      expect(html).toContain("media-src 'self' data: http: https: blob: file: history-resource: astrbot-model:")
+    }
+  })
+})

--- a/tests/htmlCsp.test.ts
+++ b/tests/htmlCsp.test.ts
@@ -12,13 +12,29 @@ function readHtml(fileName: string): string {
   return fs.readFileSync(path.join(process.cwd(), fileName), 'utf8')
 }
 
+function readCspDirectives(fileName: string): Map<string, string[]> {
+  const html = readHtml(fileName)
+  const match = html.match(/<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"/i)
+  if (!match) {
+    throw new Error(`${fileName} 缺少 Content-Security-Policy meta 标签`)
+  }
+
+  const directives = new Map<string, string[]>()
+  for (const directive of match[1].split(';').map((item) => item.trim()).filter(Boolean)) {
+    const [name, ...sources] = directive.split(/\s+/)
+    directives.set(name, sources)
+  }
+
+  return directives
+}
+
 describe('htmlCsp', () => {
   it('allows astrbot-model protocol for connect img and media sources', () => {
     for (const fileName of htmlFiles) {
-      const html = readHtml(fileName)
-      expect(html).toContain("img-src 'self' data: http: https: blob: file: history-resource: astrbot-model:")
-      expect(html).toContain("connect-src 'self' http: https: ws: wss: file: history-resource: astrbot-model:")
-      expect(html).toContain("media-src 'self' data: http: https: blob: file: history-resource: astrbot-model:")
+      const directives = readCspDirectives(fileName)
+      expect(directives.get('img-src')).toContain('astrbot-model:')
+      expect(directives.get('connect-src')).toContain('astrbot-model:')
+      expect(directives.get('media-src')).toContain('astrbot-model:')
     }
   })
 })

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -39,6 +39,8 @@ describe('metadata', () => {
 
   it('centralizes main-process user config keys', () => {
     expect(USER_CONFIG_KEYS).toEqual({
+      userId: 'user_id',
+      userName: 'user_name',
       autoUpdateEnabled: 'app_auto_update_enabled',
       screenshotDefaultTarget: 'desktop_capture_default_target',
       screenshotQuality: 'desktop_capture_quality',

--- a/welcome.html
+++ b/welcome.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource:; connect-src 'self' http: https: ws: wss: file: history-resource:; media-src 'self' data: http: https: blob: file: history-resource:" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' cubism:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: http: https: blob: file: history-resource: astrbot-model:; connect-src 'self' http: https: ws: wss: file: history-resource: astrbot-model:; media-src 'self' data: http: https: blob: file: history-resource: astrbot-model:" />
     <title>欢迎 - AstrBot Live2D Desktop</title>
   </head>
   <body>


### PR DESCRIPTION
## 变更摘要
- 统一便携版与安装版的数据目录解析，并在启动早期同步给 Electron 自身的 userData/sessionData
- 增加旧数据目录到新目录的只复制迁移逻辑，不移动、不覆盖现有运行时数据
- 收口 user_id 与 user_name 配置键定义，补充对应测试
- 放行 astrbot-model 协议的 CSP，修复模型文件通过 fetch 加载时被浏览器层拦截的问题

## 验证
- pnpm exec vitest run tests/metadata.test.ts tests/windowWatcherConfig.test.ts tests/appPaths.test.ts tests/appDataMigration.test.ts
- pnpm exec vue-tsc --noEmit
- pnpm exec vitest run tests/htmlCsp.test.ts

## Summary by Sourcery

Unify application data directory handling across portable and installed modes, add a one-time copy-based migration for existing user data, centralize user profile config keys, and relax CSP to allow astrbot-model protocol access for model assets.

New Features:
- Introduce a shared app data path resolver used by database, models, logging, and window watcher configuration.
- Add a copy-based migration from legacy user data locations into the new app data directory without overwriting existing files.

Bug Fixes:
- Allow astrbot-model protocol resources to load under the HTML Content-Security-Policy to fix model fetch failures.

Enhancements:
- Centralize user_id and user_name configuration keys with tests to keep main-process user config definitions consistent.
- Log the resolved data directory mode and locations at startup for easier diagnostics.

Tests:
- Add tests for app data path resolution, migration behavior, and HTML CSP to validate new storage and loading rules.