### PR TITLE
refactor: 重构连接生命周期与状态同步

### DIFF
--- a/electron/bridge/BridgeConnectionController.ts
+++ b/electron/bridge/BridgeConnectionController.ts
@@ -1,0 +1,569 @@
+import { EventEmitter } from 'events'
+import type { ConnectionSettingsPersistedV3 } from '../../src/shared/connectionSettings'
+import type { ConnectionBehaviorSettingsPersistedV1 } from '../../src/shared/connectionBehaviorSettings'
+import {
+  buildDefaultBridgeLifecycleSnapshot,
+  type BridgeLifecycleCommandResult,
+  type BridgeLifecycleSnapshot,
+} from '../../src/shared/bridgeLifecycle'
+import { validateBridgeEndpointDraft } from '../../src/shared/bridgeConnectionValidation'
+import { buildDefaultConnectionSettingsSnapshot, loadConnectionSettings } from '../services/connectionSettingsService'
+import { loadConnectionBehaviorSettingsRecord } from '../services/connectionBehaviorSettingsService'
+import { L2DBridgeClient, type BridgeClientDisconnectInfo } from '../protocol/client'
+import type { InputMessagePayload, MessageContent } from '../protocol/types'
+import { classifyConnectError, classifyDisconnect, type BridgeFailure } from './bridgeFailureClassifier'
+import { calculateRetryDelayMs } from './bridgeRetryPolicy'
+
+type LifecycleEventMap = {
+  stateChanged: (snapshot: BridgeLifecycleSnapshot) => void
+  'perform:show': (payload: unknown) => void
+  'perform:interrupt': () => void
+  'stt:result': (payload: unknown) => void
+}
+
+type DisconnectSource = 'manual' | 'socket-close' | 'socket-error' | 'system-suspend' | 'settings-changed'
+type ConnectReason = 'startup' | 'manual' | 'retry' | 'resume' | 'settings-changed'
+
+function toDisconnectEvent(source: DisconnectSource, failure?: BridgeFailure): BridgeLifecycleSnapshot['lastDisconnect'] {
+  return {
+    source,
+    code: failure?.closeCode,
+    reason: failure?.closeReason,
+    at: Date.now(),
+  }
+}
+
+function isTransportLayerChanged(
+  previousSettings: ConnectionSettingsPersistedV3,
+  nextSettings: ConnectionSettingsPersistedV3,
+): boolean {
+  return previousSettings.serverUrl !== nextSettings.serverUrl
+    || previousSettings.token !== nextSettings.token
+}
+
+export class BridgeConnectionController extends EventEmitter {
+  private snapshot = buildDefaultBridgeLifecycleSnapshot()
+  private behaviorSettings: ConnectionBehaviorSettingsPersistedV1 = loadConnectionBehaviorSettingsRecord().settings
+  private startupDecisionPending = true
+  private initialized = false
+  private hasUserDrivenAction = false
+  private currentSettings: ConnectionSettingsPersistedV3 = buildDefaultConnectionSettingsSnapshot()
+  private retryTimer: NodeJS.Timeout | null = null
+  private currentGeneration = 0
+  private pendingClient: L2DBridgeClient | null = null
+  private activeClient: L2DBridgeClient | null = null
+  private activeClientListeners: Array<{ event: string; listener: (...args: any[]) => void }> = []
+
+  override on<K extends keyof LifecycleEventMap>(eventName: K, listener: LifecycleEventMap[K]): this {
+    return super.on(eventName, listener)
+  }
+
+  override emit<K extends keyof LifecycleEventMap>(eventName: K, ...args: Parameters<LifecycleEventMap[K]>): boolean {
+    return super.emit(eventName, ...args)
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return
+    }
+
+    const connectionLoadResult = loadConnectionSettings()
+    if (connectionLoadResult.success) {
+      this.currentSettings = connectionLoadResult.data
+    } else {
+      console.error('[BridgeConnectionController] 读取连接配置失败:', connectionLoadResult.code, connectionLoadResult.message)
+      this.currentSettings = buildDefaultConnectionSettingsSnapshot()
+    }
+
+    const behaviorRecord = loadConnectionBehaviorSettingsRecord()
+    this.behaviorSettings = behaviorRecord.settings
+    this.startupDecisionPending = !behaviorRecord.exists
+
+    this.applySnapshot({
+      activeConfigRevision: this.currentSettings.revision,
+      serverUrl: this.currentSettings.serverUrl,
+      hasToken: Boolean(this.currentSettings.token.trim()),
+    })
+
+    this.initialized = true
+
+    if (!this.startupDecisionPending && this.behaviorSettings.autoConnectOnAppLaunch) {
+      this.applySnapshot({ desiredState: 'connected' })
+      await this.openCurrentSettings('startup')
+    }
+  }
+
+  dispose(): void {
+    this.cancelRetryTimer()
+    this.closePendingClient()
+    this.closeActiveClient()
+  }
+
+  getSnapshot(): BridgeLifecycleSnapshot {
+    return { ...this.snapshot }
+  }
+
+  getSession() {
+    return this.snapshot.session
+  }
+
+  isConnected(): boolean {
+    return this.snapshot.status === 'connected' && !!this.activeClient?.isReady()
+  }
+
+  async connect(): Promise<BridgeLifecycleCommandResult> {
+    const validation = validateBridgeEndpointDraft({
+      serverUrl: this.currentSettings.serverUrl,
+      token: this.currentSettings.token,
+    })
+
+    if (!validation.valid) {
+      return {
+        success: false,
+        code: validation.code,
+        message: validation.message,
+        snapshot: this.getSnapshot(),
+      }
+    }
+
+    this.hasUserDrivenAction = true
+    this.applySnapshot({
+      desiredState: 'connected',
+      suspendReason: null,
+    })
+
+    return await this.openCurrentSettings('manual')
+  }
+
+  async disconnect(): Promise<BridgeLifecycleCommandResult> {
+    this.hasUserDrivenAction = true
+    this.cancelRetryTimer()
+    this.closePendingClient()
+    this.closeActiveClient()
+
+    this.applySnapshot({
+      status: 'idle',
+      desiredState: 'disconnected',
+      session: null,
+      reconnectAttempt: 0,
+      nextRetryAt: null,
+      suspendReason: null,
+      lastError: null,
+      lastDisconnect: toDisconnectEvent('manual'),
+    })
+
+    return {
+      success: true,
+      snapshot: this.getSnapshot(),
+    }
+  }
+
+  async handleConnectionSettingsUpdated(settings: ConnectionSettingsPersistedV3): Promise<void> {
+    const previousSettings = this.currentSettings
+    this.currentSettings = settings
+
+    this.applySnapshot({
+      activeConfigRevision: settings.revision,
+      serverUrl: settings.serverUrl,
+      hasToken: Boolean(settings.token.trim()),
+    })
+
+    if (this.snapshot.desiredState !== 'connected') {
+      return
+    }
+
+    if (isTransportLayerChanged(previousSettings, settings)) {
+      await this.restartWithCurrentSettings('settings-changed')
+    }
+  }
+
+  async handleBehaviorSettingsUpdated(
+    settings: ConnectionBehaviorSettingsPersistedV1,
+    options: { resolveStartupDecision?: boolean } = {},
+  ): Promise<void> {
+    this.behaviorSettings = settings
+
+    if (options.resolveStartupDecision && this.startupDecisionPending) {
+      this.startupDecisionPending = false
+      if (!this.hasUserDrivenAction && settings.autoConnectOnAppLaunch && this.snapshot.desiredState === 'disconnected') {
+        this.applySnapshot({ desiredState: 'connected' })
+        await this.openCurrentSettings('startup')
+        return
+      }
+    }
+
+    if (this.snapshot.status === 'waiting_retry' && this.snapshot.desiredState === 'connected') {
+      if (!settings.retryEnabled) {
+        this.cancelRetryTimer()
+        this.applySnapshot({
+          status: 'error',
+          nextRetryAt: null,
+        })
+      } else {
+        this.scheduleRetry({
+          code: this.snapshot.lastError?.code || 'WS_UNEXPECTED_CLOSE',
+          message: this.snapshot.lastError?.message || '连接已断开',
+          retryable: true,
+        })
+      }
+      return
+    }
+
+    if (
+      this.snapshot.status === 'error'
+      && this.snapshot.desiredState === 'connected'
+      && this.snapshot.lastError?.retryable
+      && settings.retryEnabled
+    ) {
+      this.scheduleRetry({
+        code: this.snapshot.lastError.code,
+        message: this.snapshot.lastError.message,
+        retryable: true,
+      })
+    }
+  }
+
+  async handleSystemSuspend(reason: 'lock-screen' | 'suspend'): Promise<void> {
+    if (this.snapshot.desiredState !== 'connected') {
+      return
+    }
+
+    this.cancelRetryTimer()
+    this.closePendingClient()
+    this.closeActiveClient()
+
+    if (this.behaviorSettings.resumeDesiredConnectionOnWake) {
+      this.applySnapshot({
+        status: 'suspended',
+        session: null,
+        nextRetryAt: null,
+        suspendReason: reason,
+        lastDisconnect: toDisconnectEvent('system-suspend'),
+      })
+      return
+    }
+
+    this.applySnapshot({
+      status: 'idle',
+      desiredState: 'disconnected',
+      session: null,
+      reconnectAttempt: 0,
+      nextRetryAt: null,
+      suspendReason: null,
+      lastError: null,
+      lastDisconnect: toDisconnectEvent('system-suspend'),
+    })
+  }
+
+  async handleSystemResume(): Promise<void> {
+    if (this.snapshot.status !== 'suspended' || this.snapshot.desiredState !== 'connected') {
+      return
+    }
+
+    this.applySnapshot({ suspendReason: null })
+    await this.openCurrentSettings('resume')
+  }
+
+  async sendMessage(payload: InputMessagePayload): Promise<MessageContent[]> {
+    if (!this.activeClient?.isReady()) {
+      throw new Error('未连接到服务器')
+    }
+
+    return await this.activeClient.sendMessage(payload)
+  }
+
+  sendTouch(x: number, y: number, action: string): void {
+    if (!this.activeClient?.isReady()) {
+      throw new Error('未连接到服务器')
+    }
+
+    this.activeClient.sendTouch(x, y, action)
+  }
+
+  sendState(op: string, payload: unknown): void {
+    if (!this.activeClient?.isReady()) {
+      throw new Error('未连接到服务器')
+    }
+
+    this.activeClient.sendState(op, payload)
+  }
+
+  private async restartWithCurrentSettings(reason: ConnectReason): Promise<void> {
+    this.cancelRetryTimer()
+    this.closePendingClient()
+    this.closeActiveClient()
+    await this.openCurrentSettings(reason)
+  }
+
+  private async openCurrentSettings(reason: ConnectReason): Promise<BridgeLifecycleCommandResult> {
+    const validation = validateBridgeEndpointDraft({
+      serverUrl: this.currentSettings.serverUrl,
+      token: this.currentSettings.token,
+    })
+
+    if (!validation.valid) {
+      this.applyFailure(
+        {
+          code: validation.code,
+          message: validation.message,
+          retryable: false,
+        },
+        reason === 'settings-changed' ? 'settings-changed' : 'socket-error',
+      )
+
+      return {
+        success: false,
+        code: validation.code,
+        message: validation.message,
+        snapshot: this.getSnapshot(),
+      }
+    }
+
+    const generation = ++this.currentGeneration
+    this.cancelRetryTimer()
+    this.closePendingClient()
+    this.closeActiveClient()
+
+    const reconnectAttempt = reason === 'retry' ? this.snapshot.reconnectAttempt : 0
+    this.applySnapshot({
+      status: 'connecting',
+      desiredState: 'connected',
+      session: null,
+      reconnectAttempt,
+      nextRetryAt: null,
+      suspendReason: null,
+      lastError: null,
+      activeConfigRevision: this.currentSettings.revision,
+      serverUrl: this.currentSettings.serverUrl,
+      hasToken: Boolean(this.currentSettings.token.trim()),
+    })
+
+    const candidateClient = new L2DBridgeClient()
+    this.pendingClient = candidateClient
+
+    try {
+      const session = await candidateClient.open({
+        url: this.currentSettings.serverUrl,
+        token: this.currentSettings.token,
+        handshakeTimeoutMs: this.behaviorSettings.handshakeTimeoutMs,
+        onSocketOpen: () => {
+          if (generation !== this.currentGeneration || this.pendingClient !== candidateClient) {
+            return
+          }
+          this.applySnapshot({ status: 'handshaking' })
+        },
+      })
+
+      if (generation !== this.currentGeneration || this.pendingClient !== candidateClient || this.snapshot.desiredState !== 'connected') {
+        candidateClient.close()
+        return {
+          success: true,
+          snapshot: this.getSnapshot(),
+        }
+      }
+
+      this.pendingClient = null
+      this.promoteActiveClient(candidateClient, generation)
+      this.applySnapshot({
+        status: 'connected',
+        session,
+        reconnectAttempt: 0,
+        nextRetryAt: null,
+        suspendReason: null,
+        lastError: null,
+      })
+
+      return {
+        success: true,
+        snapshot: this.getSnapshot(),
+      }
+    } catch (error) {
+      if (generation !== this.currentGeneration) {
+        return {
+          success: false,
+          code: 'CLIENT_UNAVAILABLE',
+          message: '连接请求已被更新的生命周期操作取代',
+          snapshot: this.getSnapshot(),
+        }
+      }
+
+      if (this.pendingClient === candidateClient) {
+        this.pendingClient = null
+      }
+      candidateClient.close()
+
+      const failure = classifyConnectError(error)
+      this.applyFailure(failure, 'socket-error')
+
+      return {
+        success: false,
+        code: failure.code,
+        message: failure.message,
+        snapshot: this.getSnapshot(),
+      }
+    }
+  }
+
+  private promoteActiveClient(client: L2DBridgeClient, generation: number): void {
+    this.activeClient = client
+
+    const onDisconnected = (info: BridgeClientDisconnectInfo) => {
+      if (generation !== this.currentGeneration || this.activeClient !== client) {
+        return
+      }
+
+      this.activeClient = null
+      this.clearActiveClientListeners()
+      const failure = classifyDisconnect(info)
+      this.applyFailure(failure, 'socket-close')
+    }
+
+    const onPerformShow = (payload: unknown) => {
+      if (generation === this.currentGeneration && this.activeClient === client) {
+        this.emit('perform:show', payload)
+      }
+    }
+
+    const onPerformInterrupt = () => {
+      if (generation === this.currentGeneration && this.activeClient === client) {
+        this.emit('perform:interrupt')
+      }
+    }
+
+    const onSttResult = (payload: unknown) => {
+      if (generation === this.currentGeneration && this.activeClient === client) {
+        this.emit('stt:result', payload)
+      }
+    }
+
+    client.on('disconnected', onDisconnected)
+    client.on('perform:show', onPerformShow)
+    client.on('perform:interrupt', onPerformInterrupt)
+    client.on('stt:result', onSttResult)
+
+    this.activeClientListeners = [
+      { event: 'disconnected', listener: onDisconnected },
+      { event: 'perform:show', listener: onPerformShow },
+      { event: 'perform:interrupt', listener: onPerformInterrupt },
+      { event: 'stt:result', listener: onSttResult },
+    ]
+  }
+
+  private clearActiveClientListeners(): void {
+    if (!this.activeClient) {
+      this.activeClientListeners = []
+      return
+    }
+
+    for (const { event, listener } of this.activeClientListeners) {
+      this.activeClient.off(event, listener)
+    }
+    this.activeClientListeners = []
+  }
+
+  private closePendingClient(): void {
+    if (!this.pendingClient) {
+      return
+    }
+
+    const pendingClient = this.pendingClient
+    this.pendingClient = null
+    pendingClient.close()
+  }
+
+  private closeActiveClient(): void {
+    if (!this.activeClient) {
+      return
+    }
+
+    const activeClient = this.activeClient
+    this.clearActiveClientListeners()
+    this.activeClient = null
+    activeClient.close()
+  }
+
+  private cancelRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+  }
+
+  private scheduleRetry(failure: BridgeFailure): void {
+    if (this.snapshot.desiredState !== 'connected' || !failure.retryable || !this.behaviorSettings.retryEnabled) {
+      this.applySnapshot({
+        status: 'error',
+        nextRetryAt: null,
+      })
+      return
+    }
+
+    const nextAttempt = Math.max(1, this.snapshot.reconnectAttempt + 1)
+    if (
+      this.behaviorSettings.retryMaxAttempts !== null
+      && nextAttempt > this.behaviorSettings.retryMaxAttempts
+    ) {
+      this.applySnapshot({
+        status: 'error',
+        reconnectAttempt: nextAttempt - 1,
+        nextRetryAt: null,
+      })
+      return
+    }
+
+    this.cancelRetryTimer()
+
+    const delay = calculateRetryDelayMs(this.behaviorSettings, nextAttempt)
+    const nextRetryAt = Date.now() + delay
+    this.applySnapshot({
+      status: 'waiting_retry',
+      reconnectAttempt: nextAttempt,
+      nextRetryAt,
+    })
+
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      if (this.snapshot.desiredState !== 'connected') {
+        return
+      }
+      void this.openCurrentSettings('retry')
+    }, delay)
+  }
+
+  private applyFailure(failure: BridgeFailure, disconnectSource: DisconnectSource): void {
+    this.cancelRetryTimer()
+    this.closePendingClient()
+
+    this.applySnapshot({
+      session: null,
+      lastError: {
+        code: failure.code,
+        message: failure.message,
+        retryable: failure.retryable,
+        at: Date.now(),
+      },
+      lastDisconnect: toDisconnectEvent(disconnectSource, failure),
+      nextRetryAt: null,
+      suspendReason: null,
+    })
+
+    if (failure.retryable && this.snapshot.desiredState === 'connected' && this.behaviorSettings.retryEnabled) {
+      this.scheduleRetry(failure)
+      return
+    }
+
+    this.applySnapshot({
+      status: 'error',
+      nextRetryAt: null,
+    })
+  }
+
+  private applySnapshot(patch: Partial<BridgeLifecycleSnapshot>): void {
+    this.snapshot = {
+      ...this.snapshot,
+      ...patch,
+      updatedAt: Date.now(),
+    }
+    this.emit('stateChanged', this.getSnapshot())
+  }
+}

--- a/electron/bridge/bridgeFailureClassifier.ts
+++ b/electron/bridge/bridgeFailureClassifier.ts
@@ -1,0 +1,56 @@
+import type { BridgeLifecycleErrorCode } from '../../src/shared/bridgeLifecycle'
+import type { BridgeClientDisconnectInfo, BridgeClientError } from '../protocol/client'
+
+export interface BridgeFailure {
+  code: BridgeLifecycleErrorCode
+  message: string
+  retryable: boolean
+  closeCode?: number
+  closeReason?: string
+}
+
+function isBridgeClientError(error: unknown): error is BridgeClientError {
+  return Boolean(error) && typeof error === 'object' && typeof (error as BridgeClientError).code === 'string'
+}
+
+export function classifyConnectError(error: unknown): BridgeFailure {
+  if (isBridgeClientError(error)) {
+    const retryable = error.code !== 'INVALID_URL'
+      && error.code !== 'TOKEN_REQUIRED'
+      && error.code !== 'AUTH_FAILED'
+      && error.code !== 'VERSION_MISMATCH'
+    return {
+      code: error.code,
+      message: error.message,
+      retryable,
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: 'WS_CONNECT_FAILED',
+      message: error.message,
+      retryable: true,
+    }
+  }
+
+  return {
+    code: 'UNKNOWN',
+    message: String(error),
+    retryable: true,
+  }
+}
+
+export function classifyDisconnect(info: BridgeClientDisconnectInfo): BridgeFailure {
+  const code = info.errorCode || 'WS_UNEXPECTED_CLOSE'
+  const message = info.errorMessage || `连接已断开: ${info.reason || info.code}`
+  const retryable = code !== 'AUTH_FAILED' && code !== 'VERSION_MISMATCH'
+
+  return {
+    code,
+    message,
+    retryable,
+    closeCode: info.code,
+    closeReason: info.reason,
+  }
+}

--- a/electron/bridge/bridgeRetryPolicy.ts
+++ b/electron/bridge/bridgeRetryPolicy.ts
@@ -1,0 +1,12 @@
+import type { ConnectionBehaviorSettingsPersistedV1 } from '../../src/shared/connectionBehaviorSettings'
+
+export function calculateRetryDelayMs(
+  settings: ConnectionBehaviorSettingsPersistedV1,
+  reconnectAttempt: number,
+): number {
+  const normalizedAttempt = Math.max(1, reconnectAttempt)
+  return Math.min(
+    settings.retryBaseDelayMs * Math.pow(2, normalizedAttempt - 1),
+    settings.retryMaxDelayMs,
+  )
+}

--- a/electron/ipc/bridgeLifecycle.ts
+++ b/electron/ipc/bridgeLifecycle.ts
@@ -1,0 +1,36 @@
+import { ipcMain } from 'electron'
+import { buildDefaultBridgeLifecycleSnapshot } from '../../src/shared/bridgeLifecycle'
+import { getBridgeConnectionController } from '../main'
+
+ipcMain.handle('bridgeLifecycle:getSnapshot', async () => {
+  const controller = getBridgeConnectionController()
+  return controller ? controller.getSnapshot() : buildDefaultBridgeLifecycleSnapshot()
+})
+
+ipcMain.handle('bridgeLifecycle:connect', async () => {
+  const controller = getBridgeConnectionController()
+  if (!controller) {
+    return {
+      success: false,
+      code: 'CLIENT_UNAVAILABLE' as const,
+      message: '连接控制器未初始化',
+      snapshot: buildDefaultBridgeLifecycleSnapshot(),
+    }
+  }
+
+  return await controller.connect()
+})
+
+ipcMain.handle('bridgeLifecycle:disconnect', async () => {
+  const controller = getBridgeConnectionController()
+  if (!controller) {
+    return {
+      success: false,
+      code: 'CLIENT_UNAVAILABLE' as const,
+      message: '连接控制器未初始化',
+      snapshot: buildDefaultBridgeLifecycleSnapshot(),
+    }
+  }
+
+  return await controller.disconnect()
+})

--- a/electron/ipc/connection.ts
+++ b/electron/ipc/connection.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
-import { getBridgeClient } from '../main'
 import type { InputMessagePayload } from '../protocol/types'
+import { getBridgeConnectionController } from '../main'
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -9,184 +9,58 @@ function toErrorMessage(error: unknown): string {
   if (typeof error === 'string') {
     return error
   }
+  if (error && typeof error === 'object' && typeof (error as { message?: unknown }).message === 'string') {
+    return (error as { message: string }).message
+  }
   return String(error)
 }
 
-function getBridgeUrlValidationError(rawUrl: string): string | null {
-  let parsedUrl: URL
-
-  try {
-    parsedUrl = new URL(rawUrl)
-  } catch {
-    return '服务器地址格式无效，请填写完整的 WebSocket 地址'
-  }
-
-  if (parsedUrl.protocol !== 'ws:' && parsedUrl.protocol !== 'wss:') {
-    return '服务器地址必须使用 ws 或 wss 协议'
-  }
-
-  return null
-}
-
-function waitForBridgeReady(client: NonNullable<ReturnType<typeof getBridgeClient>>, timeoutMs: number = 8000): Promise<void> {
-  if (client.isConnected()) {
-    return Promise.resolve()
-  }
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup()
-      reject(new Error('连接已建立但握手未完成，请检查服务端状态与认证配置'))
-    }, timeoutMs)
-
-    const onConnected = () => {
-      cleanup()
-      resolve()
-    }
-
-    const onDisconnected = (info: any) => {
-      cleanup()
-      reject(new Error(`连接在握手阶段断开: ${info?.reason || info?.code || 'unknown'}`))
-    }
-
-    const onError = (error: unknown) => {
-      cleanup()
-      reject(new Error(toErrorMessage(error)))
-    }
-
-    const cleanup = () => {
-      clearTimeout(timeout)
-      client.off('connected', onConnected)
-      client.off('disconnected', onDisconnected)
-      client.off('error', onError)
-    }
-
-    client.on('connected', onConnected)
-    client.on('disconnected', onDisconnected)
-    client.on('error', onError)
-  })
-}
-
-/**
- * 连接到服务器
- */
-ipcMain.handle('bridge:connect', async (_event, url: string, token?: string) => {
-  try {
-    const client = getBridgeClient()
-    if (!client) {
-      throw new Error('客户端未初始化')
-    }
-
-    const targetUrl = (url || '').trim()
-    if (!targetUrl) {
-      throw new Error('服务器地址不能为空')
-    }
-
-    const urlValidationError = getBridgeUrlValidationError(targetUrl)
-    if (urlValidationError) {
-      throw new Error(urlValidationError)
-    }
-
-    const authToken = (token || '').trim()
-    if (!authToken) {
-      throw new Error('认证密钥不能为空，请在设置中填写后再连接')
-    }
-
-    await client.connect(targetUrl, authToken)
-    await waitForBridgeReady(client)
-    return { success: true }
-  } catch (error: any) {
-    console.error('[IPC] 连接失败:', error)
-    return { success: false, error: error.message }
-  }
-})
-
-/**
- * 断开连接
- */
-ipcMain.handle('bridge:disconnect', async () => {
-  try {
-    const client = getBridgeClient()
-    if (client) {
-      client.disconnect()
-    }
-    return { success: true }
-  } catch (error: any) {
-    console.error('[IPC] 断开连接失败:', error)
-    return { success: false, error: error.message }
-  }
-})
-
-/**
- * 获取连接状态
- */
-ipcMain.handle('bridge:isConnected', async () => {
-  const client = getBridgeClient()
-  return client ? client.isConnected() : false
-})
-
-/**
- * 获取会话信息
- */
 ipcMain.handle('bridge:getSession', async () => {
-  const client = getBridgeClient()
-  return client ? client.getSession() : null
+  const controller = getBridgeConnectionController()
+  return controller ? controller.getSession() : null
 })
 
-/**
- * 发送消息
- */
 ipcMain.handle('bridge:sendMessage', async (_event, payload: InputMessagePayload) => {
   try {
-    const client = getBridgeClient()
-    if (!client) {
-      throw new Error('客户端未初始化')
+    const controller = getBridgeConnectionController()
+    if (!controller) {
+      throw new Error('连接控制器未初始化')
     }
 
-    if (!client.isConnected()) {
-      throw new Error('未连接到服务器')
-    }
-
-    const preparedContent = await client.sendMessage(payload)
+    const preparedContent = await controller.sendMessage(payload)
     return { success: true, content: preparedContent }
-  } catch (error: any) {
+  } catch (error) {
     console.error('[IPC] 发送消息失败:', error)
-    return { success: false, error: error.message }
+    return { success: false, error: toErrorMessage(error) }
   }
 })
 
-/**
- * 发送触摸事件
- */
 ipcMain.handle('bridge:sendTouch', async (_event, x: number, y: number, action: string) => {
   try {
-    const client = getBridgeClient()
-    if (!client) {
-      throw new Error('客户端未初始化')
+    const controller = getBridgeConnectionController()
+    if (!controller) {
+      throw new Error('连接控制器未初始化')
     }
 
-    client.sendTouch(x, y, action)
+    controller.sendTouch(x, y, action)
     return { success: true }
-  } catch (error: any) {
+  } catch (error) {
     console.error('[IPC] 发送触摸事件失败:', error)
-    return { success: false, error: error.message }
+    return { success: false, error: toErrorMessage(error) }
   }
 })
 
-/**
- * 发送状态
- */
 ipcMain.handle('bridge:sendState', async (_event, op: string, payload: any) => {
   try {
-    const client = getBridgeClient()
-    if (!client) {
-      throw new Error('客户端未初始化')
+    const controller = getBridgeConnectionController()
+    if (!controller) {
+      throw new Error('连接控制器未初始化')
     }
 
-    client.sendState(op, payload)
+    controller.sendState(op, payload)
     return { success: true }
-  } catch (error: any) {
+  } catch (error) {
     console.error('[IPC] 发送状态失败:', error)
-    return { success: false, error: error.message }
+    return { success: false, error: toErrorMessage(error) }
   }
 })

--- a/electron/ipc/connectionBehaviorSettings.ts
+++ b/electron/ipc/connectionBehaviorSettings.ts
@@ -1,0 +1,59 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import type {
+  ConnectionBehaviorSettingsChangedEvent,
+  ConnectionBehaviorSettingsSavePayload,
+} from '../../src/shared/connectionBehaviorSettings'
+import {
+  loadConnectionBehaviorSettings,
+  migrateLegacyConnectionBehaviorSettings,
+  saveConnectionBehaviorSettings,
+} from '../services/connectionBehaviorSettingsService'
+import { getBridgeConnectionController } from '../main'
+
+function getSourceWindowId(event: Electron.IpcMainInvokeEvent): number | undefined {
+  const senderWindow = BrowserWindow.fromWebContents(event.sender)
+  if (!senderWindow || senderWindow.isDestroyed()) {
+    return undefined
+  }
+  return senderWindow.id
+}
+
+function broadcastBehaviorSettingsChanged(
+  settings: ConnectionBehaviorSettingsChangedEvent['settings'],
+  sourceWindowId?: number,
+): void {
+  const payload: ConnectionBehaviorSettingsChangedEvent = {
+    settings,
+    sourceWindowId,
+  }
+
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send('connectionBehaviorSettings:changed', payload)
+    }
+  }
+}
+
+ipcMain.handle('connectionBehaviorSettings:load', async () => {
+  return loadConnectionBehaviorSettings()
+})
+
+ipcMain.handle('connectionBehaviorSettings:save', async (event, payload: ConnectionBehaviorSettingsSavePayload) => {
+  const result = saveConnectionBehaviorSettings(payload)
+  if (result.success) {
+    await getBridgeConnectionController()?.handleBehaviorSettingsUpdated(result.data)
+    broadcastBehaviorSettingsChanged(result.data, getSourceWindowId(event))
+  }
+  return result
+})
+
+ipcMain.handle('connectionBehaviorSettings:migrateLegacy', async (event, rawLegacyJson: string) => {
+  const result = migrateLegacyConnectionBehaviorSettings(rawLegacyJson)
+  if (result.success) {
+    await getBridgeConnectionController()?.handleBehaviorSettingsUpdated(result.data, {
+      resolveStartupDecision: true,
+    })
+    broadcastBehaviorSettingsChanged(result.data, getSourceWindowId(event))
+  }
+  return result
+})

--- a/electron/ipc/connectionSettings.ts
+++ b/electron/ipc/connectionSettings.ts
@@ -8,6 +8,7 @@ import {
   migrateLegacyConnectionSettings,
   saveConnectionSettings,
 } from '../services/connectionSettingsService'
+import { getBridgeConnectionController } from '../main'
 
 function getSourceWindowId(event: Electron.IpcMainInvokeEvent): number | undefined {
   const senderWindow = BrowserWindow.fromWebContents(event.sender)
@@ -41,6 +42,7 @@ ipcMain.handle('connectionSettings:load', async () => {
 ipcMain.handle('connectionSettings:save', async (event, payload: ConnectionSettingsSavePayload) => {
   const result = saveConnectionSettings(payload)
   if (result.success) {
+    await getBridgeConnectionController()?.handleConnectionSettingsUpdated(result.data)
     broadcastSettingsChanged(result.data, getSourceWindowId(event))
   }
   return result
@@ -49,8 +51,8 @@ ipcMain.handle('connectionSettings:save', async (event, payload: ConnectionSetti
 ipcMain.handle('connectionSettings:migrateLegacy', async (event, rawLegacyJson: string) => {
   const result = migrateLegacyConnectionSettings(rawLegacyJson)
   if (result.success) {
+    await getBridgeConnectionController()?.handleConnectionSettingsUpdated(result.data)
     broadcastSettingsChanged(result.data, getSourceWindowId(event))
   }
   return result
 })
-

--- a/electron/ipc/user.ts
+++ b/electron/ipc/user.ts
@@ -3,7 +3,6 @@ import { setUserName, getUserName, getUserId } from '../database/schema'
 import { createMainWindow } from '../windows/mainWindow'
 import { closeWelcomeWindow } from '../windows/welcomeWindow'
 import { createTray } from '../utils/tray'
-import { initBridgeClient } from '../main'
 
 /**
  * 设置用户名称
@@ -16,9 +15,6 @@ ipcMain.handle('user:setUserName', async (_event, name: string) => {
     closeWelcomeWindow()
     createMainWindow()
     createTray()
-
-    // 初始化 Bridge 客户端
-    initBridgeClient()
 
     return { success: true }
   } catch (error) {

--- a/electron/ipc/window.ts
+++ b/electron/ipc/window.ts
@@ -312,7 +312,7 @@ ipcMain.handle('window:getPlatformCapabilities', async () => {
  */
 import { getWindowWatcher } from '../utils/windowWatcher'
 import type { WindowEvent } from '../utils/windowWatcher'
-import { bridgeClient } from '../main'
+import { getBridgeConnectionController } from '../main'
 import { getUserName } from '../database/schema'
 
 // 存储已注册的渲染进程
@@ -375,10 +375,12 @@ ipcMain.handle('window:startWatching', async (event) => {
   if (!appLaunchListenerRegistered) {
     appLaunchListenerRegistered = true
     removeAppLaunchListener = watcher.onAppLaunch((appName: string) => {
-      if (!bridgeClient?.isConnected()) return
-      const session = bridgeClient.getSession()
+      const controller = getBridgeConnectionController()
+      if (!controller?.isConnected()) return
+      const session = controller.getSession()
+      if (!session) return
       const userName = getUserName()?.trim() || 'Desktop User'
-      bridgeClient.sendMessage({
+      void controller.sendMessage({
         content: [
           {
             type: 'text',
@@ -391,6 +393,8 @@ ipcMain.handle('window:startWatching', async (event) => {
           sessionId: session.sessionId,
           messageType: 'notify',
         },
+      }).catch((error) => {
+        console.error('[窗口监听] 发送应用启动通知失败:', error)
       })
     })
   }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,7 +3,7 @@ import { APP_METADATA } from '../src/shared/metadata'
 import { createMainWindow } from './windows/mainWindow'
 import { createWelcomeWindow } from './windows/welcomeWindow'
 import { initDatabase, closeDatabase, getUserName } from './database/schema'
-import { L2DBridgeClient } from './protocol/client'
+import { BridgeConnectionController } from './bridge/BridgeConnectionController'
 import { createTray, destroyTray } from './utils/tray'
 import { cleanupShortcuts } from './ipc/shortcut'
 import { getDesktopBehaviorCoordinator } from './desktopBehavior/coordinator'
@@ -24,6 +24,8 @@ import './ipc/user'
 import './ipc/log'
 import './ipc/update'
 import './ipc/connectionSettings'
+import './ipc/connectionBehaviorSettings'
+import './ipc/bridgeLifecycle'
 
 // 禁用 GPU 缓存以避免权限错误（可选）
 app.commandLine.appendSwitch('disable-gpu-shader-disk-cache')
@@ -39,8 +41,8 @@ if (process.platform === 'win32') {
 
 const appDataContext = configureElectronDataPath()
 
-// 全局 WebSocket 客户端实例
-export let bridgeClient: L2DBridgeClient | null = null
+// 全局连接控制器实例
+export let bridgeConnectionController: BridgeConnectionController | null = null
 
 initializeMainLogger()
 installMainProcessErrorHandlers()
@@ -57,7 +59,9 @@ function pauseBackgroundActivities(reason: string): void {
 
   console.log(`[主进程] 暂停后台活动: ${reason}`)
   getDesktopBehaviorCoordinator().setBackgroundPaused(true)
-  if (bridgeClient) bridgeClient.disconnect()
+  if (bridgeConnectionController) {
+    void bridgeConnectionController.handleSystemSuspend(reason === 'lock-screen' ? 'lock-screen' : 'suspend')
+  }
 }
 
 function resumeBackgroundActivities(reason: string): void {
@@ -66,15 +70,36 @@ function resumeBackgroundActivities(reason: string): void {
 
   console.log(`[主进程] 恢复后台活动: ${reason}`)
   getDesktopBehaviorCoordinator().setBackgroundPaused(false)
-  if (bridgeClient) {
-    const { url, token } = bridgeClient.getConnectionInfo()
-    if (url) {
-      bridgeClient.resetReconnect()
-      bridgeClient.connect(url, token).catch((err) => {
-        console.error('[主进程] 恢复后重连失败:', err)
-      })
-    }
+  if (bridgeConnectionController) {
+    void bridgeConnectionController.handleSystemResume().catch((err) => {
+      console.error('[主进程] 恢复后重连失败:', err)
+    })
   }
+}
+
+function broadcastToAllWindows(channel: string, payload?: unknown): void {
+  BrowserWindow.getAllWindows().forEach((win) => {
+    if (!win.isDestroyed()) {
+      win.webContents.send(channel, payload)
+    }
+  })
+}
+
+export function initBridgeConnectionController() {
+  bridgeConnectionController = new BridgeConnectionController()
+
+  bridgeConnectionController.on('stateChanged', (snapshot) => {
+    broadcastToAllWindows('bridgeLifecycle:stateChanged', snapshot)
+  })
+
+  bridgeConnectionController.on('perform:show', (payload) => {
+    broadcastToAllWindows('perform:show', payload)
+  })
+
+  bridgeConnectionController.on('perform:interrupt', () => {
+    console.log('[主进程] 收到中断指令')
+    broadcastToAllWindows('perform:interrupt')
+  })
 }
 
 /**
@@ -115,6 +140,13 @@ async function initialize() {
   // 数据库可用后再初始化更新器，避免启动竞态访问 user_config
   initializeAutoUpdater()
 
+  initBridgeConnectionController()
+  const controller = bridgeConnectionController
+  if (!controller) {
+    throw new Error('连接控制器初始化失败')
+  }
+  await controller.initialize()
+
   // 检查 Cubism Core 是否存在
   if (!checkCubismCoreExists()) {
     console.log('[主进程] Live2D SDK 不存在，提示用户下载')
@@ -143,52 +175,7 @@ async function initialize() {
     // 非首次启动，直接创建主窗口
     createMainWindow()
     createTray()
-    initBridgeClient()
   }
-}
-
-/**
- * 初始化 Bridge 客户端
- */
-export function initBridgeClient() {
-  // 创建 WebSocket 客户端
-  bridgeClient = new L2DBridgeClient()
-
-  // 监听连接事件
-  bridgeClient.on('connected', (payload) => {
-    console.log('[主进程] 已连接到服务器:', payload)
-    BrowserWindow.getAllWindows().forEach(win => {
-      win.webContents.send('bridge:connected', payload)
-    })
-    // 应用启动检测已整合到 WindowWatcherManager，由 IPC 层管理
-  })
-
-  bridgeClient.on('disconnected', (info) => {
-    console.log('[主进程] 已断开连接:', info)
-    BrowserWindow.getAllWindows().forEach(win => {
-      win.webContents.send('bridge:disconnected', info)
-    })
-  })
-
-  bridgeClient.on('error', (error) => {
-    console.error('[主进程] 连接错误:', error)
-    BrowserWindow.getAllWindows().forEach(win => {
-      win.webContents.send('bridge:error', error)
-    })
-  })
-
-  bridgeClient.on('perform:show', (payload) => {
-    BrowserWindow.getAllWindows().forEach(win => {
-      win.webContents.send('perform:show', payload)
-    })
-  })
-
-  bridgeClient.on('perform:interrupt', () => {
-    console.log('[主进程] 收到中断指令')
-    BrowserWindow.getAllWindows().forEach(win => {
-      win.webContents.send('perform:interrupt')
-    })
-  })
 }
 
 /**
@@ -246,11 +233,11 @@ app.on('window-all-closed', () => {
  */
 app.on('before-quit', () => {
   try {
-    if (bridgeClient) {
-      bridgeClient.disconnect()
+    if (bridgeConnectionController) {
+      bridgeConnectionController.dispose()
     }
   } catch (err) {
-    console.error('[主进程] 断开 Bridge 连接失败:', err)
+    console.error('[主进程] 关闭连接控制器失败:', err)
   }
   cleanupShortcuts()
   destroyTray()
@@ -264,8 +251,8 @@ app.on('before-quit', () => {
 })
 
 /**
- * 导出全局客户端实例
+ * 导出全局连接控制器实例
  */
-export function getBridgeClient(): L2DBridgeClient | null {
-  return bridgeClient
+export function getBridgeConnectionController(): BridgeConnectionController | null {
+  return bridgeConnectionController
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -48,20 +48,20 @@ function sendRendererLog(level: 'debug' | 'info' | 'warn' | 'error', args: any[]
 contextBridge.exposeInMainWorld('electron', {
   // 连接管理
   bridge: {
-    connect: (url: string, token?: string) => ipcRenderer.invoke('bridge:connect', url, token),
-    disconnect: () => ipcRenderer.invoke('bridge:disconnect'),
-    isConnected: () => ipcRenderer.invoke('bridge:isConnected'),
     getSession: () => ipcRenderer.invoke('bridge:getSession'),
     sendMessage: (payload: any) => ipcRenderer.invoke('bridge:sendMessage', payload),
     sendTouch: (x: number, y: number, action: string) => ipcRenderer.invoke('bridge:sendTouch', x, y, action),
     sendState: (op: string, payload: any) => ipcRenderer.invoke('bridge:sendState', op, payload),
 
-    // 事件监听（单订阅模式，避免重复注册堆积）
-    onConnected: (callback: (payload: any) => void) => subscribeIpc('bridge:connected', callback),
-    onDisconnected: (callback: (info: any) => void) => subscribeIpc('bridge:disconnected', callback),
-    onError: (callback: (error: any) => void) => subscribeIpc('bridge:error', callback),
     onPerformShow: (callback: (payload: any) => void) => subscribeIpc('perform:show', callback),
     onPerformInterrupt: (callback: () => void) => subscribeIpc('perform:interrupt', callback)
+  },
+
+  bridgeLifecycle: {
+    getSnapshot: () => ipcRenderer.invoke('bridgeLifecycle:getSnapshot'),
+    connect: () => ipcRenderer.invoke('bridgeLifecycle:connect'),
+    disconnect: () => ipcRenderer.invoke('bridgeLifecycle:disconnect'),
+    onStateChanged: (callback: (snapshot: any) => void) => subscribeIpc('bridgeLifecycle:stateChanged', callback),
   },
 
   // 窗口管理
@@ -131,6 +131,13 @@ contextBridge.exposeInMainWorld('electron', {
     save: (payload: any) => ipcRenderer.invoke('connectionSettings:save', payload),
     migrateLegacy: (rawLegacyJson: string) => ipcRenderer.invoke('connectionSettings:migrateLegacy', rawLegacyJson),
     onChanged: (callback: (event: any) => void) => subscribeIpc('connectionSettings:changed', callback),
+  },
+
+  connectionBehaviorSettings: {
+    load: () => ipcRenderer.invoke('connectionBehaviorSettings:load'),
+    save: (payload: any) => ipcRenderer.invoke('connectionBehaviorSettings:save', payload),
+    migrateLegacy: (rawLegacyJson: string) => ipcRenderer.invoke('connectionBehaviorSettings:migrateLegacy', rawLegacyJson),
+    onChanged: (callback: (event: any) => void) => subscribeIpc('connectionBehaviorSettings:changed', callback),
   },
 
   // 历史记录

--- a/electron/protocol/client.ts
+++ b/electron/protocol/client.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto'
 import http from 'http'
 import https from 'https'
 import { PROTOCOL_VERSION } from '../../src/shared/metadata'
+import type { BridgeLifecycleErrorCode, BridgeSessionState } from '../../src/shared/bridgeLifecycle'
 import { getUserId } from '../database/schema'
 import { resolveHttpUrl } from '../utils/urlNormalize'
 import type {
@@ -29,21 +30,61 @@ import {
   handleToolCall,
 } from '../ipc/desktop'
 
+export interface BridgeOpenOptions {
+  url: string
+  token: string
+  handshakeTimeoutMs: number
+  onSocketOpen?: () => void
+}
+
+export interface BridgeClientDisconnectInfo {
+  code: number
+  reason: string
+  errorCode: BridgeLifecycleErrorCode | null
+  errorMessage: string | null
+}
+
+export interface BridgeClientError extends Error {
+  code: BridgeLifecycleErrorCode
+}
+
+function createBridgeClientError(code: BridgeLifecycleErrorCode, message: string): BridgeClientError {
+  const error = new Error(message) as BridgeClientError
+  error.name = 'BridgeClientError'
+  error.code = code
+  return error
+}
+
+function createOpenCloseError(info: BridgeClientDisconnectInfo): BridgeClientError {
+  if (info.errorCode && info.errorMessage) {
+    return createBridgeClientError(info.errorCode, info.errorMessage)
+  }
+
+  return createBridgeClientError(
+    'WS_UNEXPECTED_CLOSE',
+    `连接在握手阶段断开: ${info.reason || info.code || 'unknown'}`,
+  )
+}
+
 /**
  * L2D-Bridge WebSocket 客户端
  */
 export class L2DBridgeClient extends EventEmitter {
   private ws: WebSocket | null = null
-  private url: string = ''
-  private token: string = ''
-  private sessionId: string = ''
-  private userId: string = ''
+  private url = ''
+  private token = ''
+  private sessionId = ''
+  private userId = ''
   private heartbeatTimer: NodeJS.Timeout | null = null
-  private reconnectTimer: NodeJS.Timeout | null = null
-  private reconnectAttempts: number = 0
-  private maxReconnectAttempts: number = 10
-  private isConnecting: boolean = false
-  private shouldReconnect: boolean = true
+  private handshakeTimer: NodeJS.Timeout | null = null
+  private ready = false
+  private pendingOpen:
+    | {
+        resolve: () => void
+        reject: (error: BridgeClientError) => void
+      }
+    | null = null
+  private pendingDisconnectError: { code: BridgeLifecycleErrorCode; message: string } | null = null
   private serverConfig: { resourceBaseUrl?: string; resourcePath?: string; maxInlineBytes?: number } = {}
   private pendingRequests: Map<string, {
     resolve: (payload: any) => void
@@ -51,38 +92,41 @@ export class L2DBridgeClient extends EventEmitter {
     timer: NodeJS.Timeout
   }> = new Map()
 
-  constructor() {
-    super()
-  }
-
   /**
-   * 连接到服务器
+   * 建立单次连接并等待握手完成
    */
-  async connect(url: string, token?: string): Promise<void> {
-    if (this.isConnecting || this.ws?.readyState === WebSocket.OPEN) {
-      return
+  async open(options: BridgeOpenOptions): Promise<BridgeSessionState> {
+    if (this.ws) {
+      throw createBridgeClientError('CLIENT_UNAVAILABLE', '连接客户端忙碌中，请稍后重试')
     }
 
-    const normalizedToken = (token || '').trim()
+    const normalizedUrl = (options.url || '').trim()
+    const normalizedToken = (options.token || '').trim()
+
     if (!normalizedToken) {
-      throw new Error('认证密钥不能为空，请在设置中填写后再连接')
+      throw createBridgeClientError('TOKEN_REQUIRED', '认证密钥不能为空，请在设置中填写后再连接')
     }
 
-    this.url = url
+    this.url = normalizedUrl
     this.token = normalizedToken
-    this.isConnecting = true
-    this.shouldReconnect = true
+    this.ready = false
+    this.pendingDisconnectError = null
+    this.resetSessionState()
 
-    return new Promise((resolve, reject) => {
+    return await new Promise<BridgeSessionState>((resolve, reject) => {
       try {
-        this.ws = new WebSocket(url)
+        this.pendingOpen = {
+          resolve: () => resolve(this.getSession()),
+          reject,
+        }
+
+        this.ws = new WebSocket(normalizedUrl)
 
         this.ws.on('open', () => {
           console.log('[L2D] WebSocket 已连接')
-          this.isConnecting = false
-          this.reconnectAttempts = 0
+          options.onSocketOpen?.()
           this.sendHandshake()
-          resolve()
+          this.startHandshakeTimeout(options.handshakeTimeoutMs)
         })
 
         this.ws.on('message', (data: Buffer) => {
@@ -95,51 +139,158 @@ export class L2DBridgeClient extends EventEmitter {
         })
 
         this.ws.on('close', (code, reason) => {
-          console.log(`[L2D] WebSocket 已断开: ${code} - ${reason}`)
-          this.isConnecting = false
-          this.stopHeartbeat()
-          this.emit('disconnected', { code, reason: reason.toString() })
-          // close 在所有断连场景都会触发（含 error 后），仅在此处安排重连
-          if (this.shouldReconnect) {
-            this.scheduleReconnect()
+          const disconnectInfo = this.handleSocketClose(code, reason.toString())
+          if (this.pendingOpen) {
+            this.rejectPendingOpen(createOpenCloseError(disconnectInfo))
+            return
+          }
+
+          if (this.ready || disconnectInfo.errorCode || disconnectInfo.errorMessage) {
+            this.emit('disconnected', disconnectInfo)
           }
         })
 
         this.ws.on('error', (error) => {
           console.error('[L2D] WebSocket 错误:', error)
-          this.isConnecting = false
-          this.emit('error', error)
-          reject(error)
+          if (this.pendingOpen) {
+            this.rejectPendingOpen(
+              createBridgeClientError(
+                'WS_CONNECT_FAILED',
+                error instanceof Error ? error.message : String(error),
+              ),
+            )
+          }
         })
       } catch (error) {
-        this.isConnecting = false
-        reject(error)
+        this.rejectPendingOpen(
+          createBridgeClientError(
+            'WS_CONNECT_FAILED',
+            error instanceof Error ? error.message : String(error),
+          ),
+        )
       }
     })
   }
 
   /**
-   * 断开连接
+   * 主动关闭连接
    */
-  disconnect(): void {
+  close(): void {
+    this.stopHandshakeTimeout()
     this.stopHeartbeat()
-    this.stopReconnect()
-    this.shouldReconnect = false
-
-    for (const [, pending] of this.pendingRequests) {
-      clearTimeout(pending.timer)
-      pending.reject(new Error('连接已断开'))
-    }
-    this.pendingRequests.clear()
 
     if (this.ws) {
-      this.ws.close()
+      const ws = this.ws
       this.ws = null
+
+      if (ws.readyState === WebSocket.CONNECTING) {
+        ws.terminate()
+      } else {
+        ws.close()
+      }
     }
 
+    if (this.pendingOpen) {
+      this.rejectPendingOpen(createBridgeClientError('CLIENT_UNAVAILABLE', '连接已关闭'))
+    }
+
+    this.clearPendingRequests(new Error('连接已断开'))
+    this.ready = false
+    this.pendingDisconnectError = null
+    this.resetSessionState()
+  }
+
+  private handleSocketClose(code: number, reason: string): BridgeClientDisconnectInfo {
+    console.log(`[L2D] WebSocket 已断开: ${code} - ${reason}`)
+    this.stopHandshakeTimeout()
+    this.stopHeartbeat()
+
+    const wasReady = this.ready
+    const disconnectInfo: BridgeClientDisconnectInfo = {
+      code,
+      reason,
+      errorCode: this.pendingDisconnectError?.code || null,
+      errorMessage: this.pendingDisconnectError?.message || null,
+    }
+
+    this.pendingDisconnectError = null
+    this.clearPendingRequests(new Error('连接已断开'))
+    this.ready = false
+    this.ws = null
+    this.resetSessionState()
+
+    if (!wasReady && !this.pendingOpen) {
+      return disconnectInfo
+    }
+
+    return disconnectInfo
+  }
+
+  private resetSessionState(): void {
     this.sessionId = ''
     this.userId = ''
     this.serverConfig = {}
+  }
+
+  private clearPendingRequests(error: Error): void {
+    for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+    }
+    this.pendingRequests.clear()
+  }
+
+  private startHandshakeTimeout(timeoutMs: number): void {
+    this.stopHandshakeTimeout()
+    this.handshakeTimer = setTimeout(() => {
+      this.rejectPendingOpen(
+        createBridgeClientError('HANDSHAKE_TIMEOUT', '连接已建立但握手未完成，请检查服务端状态与认证配置'),
+      )
+      if (this.ws) {
+        this.ws.close(1008, '握手超时')
+      }
+    }, timeoutMs)
+  }
+
+  private stopHandshakeTimeout(): void {
+    if (this.handshakeTimer) {
+      clearTimeout(this.handshakeTimer)
+      this.handshakeTimer = null
+    }
+  }
+
+  private rejectPendingOpen(error: BridgeClientError): void {
+    if (!this.pendingOpen) {
+      return
+    }
+
+    const pendingOpen = this.pendingOpen
+    this.pendingOpen = null
+    this.stopHandshakeTimeout()
+    pendingOpen.reject(error)
+  }
+
+  private resolvePendingOpen(): void {
+    if (!this.pendingOpen) {
+      return
+    }
+
+    const pendingOpen = this.pendingOpen
+    this.pendingOpen = null
+    this.stopHandshakeTimeout()
+    pendingOpen.resolve()
+  }
+
+  private markProtocolDisconnect(code: BridgeLifecycleErrorCode, message: string): void {
+    this.pendingDisconnectError = { code, message }
+    if (this.ws) {
+      this.ws.close(1008, message)
+    }
+  }
+
+  private rejectOpenWithProtocolError(code: BridgeLifecycleErrorCode, message: string): void {
+    this.rejectPendingOpen(createBridgeClientError(code, message))
+    this.markProtocolDisconnect(code, message)
   }
 
   /**
@@ -159,7 +310,7 @@ export class L2DBridgeClient extends EventEmitter {
       op: OPS.SYS_HANDSHAKE,
       id: uuidv4(),
       ts: Date.now(),
-      payload
+      payload,
     })
   }
 
@@ -172,7 +323,6 @@ export class L2DBridgeClient extends EventEmitter {
       console.log('[L2D] 收到数据包:', packet.op, safePayload)
     }
 
-    // 拦截等待中的请求响应（按 packet.id 匹配）
     const pending = this.pendingRequests.get(packet.id)
     if (pending) {
       this.pendingRequests.delete(packet.id)
@@ -191,7 +341,6 @@ export class L2DBridgeClient extends EventEmitter {
         break
 
       case OPS.SYS_PONG:
-        // 心跳响应，静默处理
         break
 
       case OPS.PERFORM_SHOW:
@@ -207,18 +356,7 @@ export class L2DBridgeClient extends EventEmitter {
         break
 
       case OPS.SYS_ERROR:
-        if (
-          packet.error?.code === ERROR_CODE.AUTH_FAILED
-          || packet.error?.code === ERROR_CODE.VERSION_MISMATCH
-        ) {
-          this.shouldReconnect = false
-          console.error('[L2D] 握手失败（认证或版本不匹配），已停止自动重连')
-
-          if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-            this.ws.close(1008, packet.error?.message || '握手失败')
-          }
-        }
-        this.emit('error', packet.error)
+        this.handleSystemErrorPacket(packet)
         break
 
       case OPS.DESKTOP_WINDOW_LIST:
@@ -238,7 +376,6 @@ export class L2DBridgeClient extends EventEmitter {
         break
 
       case OPS.STATE_READY:
-        // 服务器就绪通知，静默处理
         break
 
       default:
@@ -246,11 +383,35 @@ export class L2DBridgeClient extends EventEmitter {
     }
   }
 
+  private handleSystemErrorPacket(packet: BasePacket): void {
+    const errorCode = packet.error?.code
+    const errorMessage = packet.error?.message || '服务端返回协议错误'
+
+    if (errorCode === ERROR_CODE.AUTH_FAILED) {
+      if (this.pendingOpen) {
+        this.rejectOpenWithProtocolError('AUTH_FAILED', errorMessage)
+      } else {
+        this.markProtocolDisconnect('AUTH_FAILED', errorMessage)
+      }
+      return
+    }
+
+    if (errorCode === ERROR_CODE.VERSION_MISMATCH) {
+      if (this.pendingOpen) {
+        this.rejectOpenWithProtocolError('VERSION_MISMATCH', errorMessage)
+      } else {
+        this.markProtocolDisconnect('VERSION_MISMATCH', errorMessage)
+      }
+      return
+    }
+
+    console.error('[L2D] 收到系统错误:', packet.error)
+  }
+
   /**
    * 处理握手确认
    */
   private handleHandshakeAck(payload: HandshakeAckPayload): void {
-    // 服务器返回的 sessionId 和 userId 在 session 对象中
     const session = (payload as any).session
     this.sessionId = session?.sessionId || payload.sessionId || ''
     this.userId = session?.userId || payload.userId || ''
@@ -258,7 +419,7 @@ export class L2DBridgeClient extends EventEmitter {
     console.log('[L2D] 握手成功:', {
       sessionId: this.sessionId,
       userId: this.userId,
-      capabilities: payload.capabilities
+      capabilities: payload.capabilities,
     })
 
     this.serverConfig = {
@@ -266,17 +427,10 @@ export class L2DBridgeClient extends EventEmitter {
       resourcePath: payload.config?.resourcePath,
       maxInlineBytes: payload.config?.maxInlineBytes,
     }
-    this.shouldReconnect = true
 
+    this.ready = true
     this.startHeartbeat()
-
-    // 发送连接成功事件（包含完整的 payload）
-    this.emit('connected', {
-      sessionId: this.sessionId,
-      userId: this.userId,
-      capabilities: payload.capabilities,
-      config: payload.config
-    })
+    this.resolvePendingOpen()
   }
 
   /**
@@ -289,9 +443,9 @@ export class L2DBridgeClient extends EventEmitter {
       this.send({
         op: OPS.SYS_PING,
         id: uuidv4(),
-        ts: Date.now()
+        ts: Date.now(),
       })
-    }, 30000) // 30秒
+    }, 30000)
   }
 
   /**
@@ -301,46 +455,6 @@ export class L2DBridgeClient extends EventEmitter {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer)
       this.heartbeatTimer = null
-    }
-  }
-
-  /**
-   * 安排重连
-   */
-  private scheduleReconnect(): void {
-    if (!this.shouldReconnect) {
-      return
-    }
-
-    if (this.reconnectTimer) {
-      return // 已安排重连，去重
-    }
-
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      console.log('[L2D] 达到最大重连次数，停止重连')
-      return
-    }
-
-    this.stopReconnect()
-
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000)
-    console.log(`[L2D] ${delay}ms 后尝试重连 (${this.reconnectAttempts + 1}/${this.maxReconnectAttempts})`)
-
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectAttempts++
-      this.connect(this.url, this.token).catch((error) => {
-        console.error('[L2D] 重连失败:', error)
-      })
-    }, delay)
-  }
-
-  /**
-   * 停止重连
-   */
-  private stopReconnect(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
     }
   }
 
@@ -356,7 +470,7 @@ export class L2DBridgeClient extends EventEmitter {
       payload: {
         ...payload,
         content: preparedContent,
-      }
+      },
     })
 
     return preparedContent
@@ -370,7 +484,7 @@ export class L2DBridgeClient extends EventEmitter {
       op: OPS.INPUT_TOUCH,
       id: uuidv4(),
       ts: Date.now(),
-      payload: { x, y, action }
+      payload: { x, y, action },
     })
   }
 
@@ -382,7 +496,7 @@ export class L2DBridgeClient extends EventEmitter {
       op,
       id: uuidv4(),
       ts: Date.now(),
-      payload
+      payload,
     })
   }
 
@@ -394,7 +508,7 @@ export class L2DBridgeClient extends EventEmitter {
       op: OPS.STT_TRANSCRIBE,
       id: uuidv4(),
       ts: Date.now(),
-      payload
+      payload,
     })
   }
 
@@ -475,32 +589,19 @@ export class L2DBridgeClient extends EventEmitter {
   /**
    * 获取连接状态
    */
-  isConnected(): boolean {
-    return this.ws?.readyState === WebSocket.OPEN && !!this.sessionId
+  isReady(): boolean {
+    return this.ready && this.ws?.readyState === WebSocket.OPEN && !!this.sessionId
   }
 
   /**
    * 获取会话信息
    */
-  getSession(): {
-    sessionId: string
-    userId: string
-    config: { resourceBaseUrl?: string; resourcePath?: string; maxInlineBytes?: number }
-  } {
+  getSession(): BridgeSessionState {
     return {
       sessionId: this.sessionId,
       userId: this.userId,
-      config: { ...this.serverConfig }
+      config: { ...this.serverConfig },
     }
-  }
-
-  getConnectionInfo(): { url: string; token: string } {
-    return { url: this.url, token: this.token }
-  }
-
-  resetReconnect(): void {
-    this.reconnectAttempts = 0
-    this.stopReconnect()
   }
 
   /**
@@ -632,7 +733,7 @@ export class L2DBridgeClient extends EventEmitter {
   }
 
   private resolveHttpResourceUrl(rawUrl: string): string {
-    return resolveHttpUrl(rawUrl, this.getConnectionInfo().url)
+    return resolveHttpUrl(rawUrl, this.url)
   }
 
   /**

--- a/electron/services/connectionBehaviorSettingsService.ts
+++ b/electron/services/connectionBehaviorSettingsService.ts
@@ -1,0 +1,184 @@
+import { getUserConfig, setUserConfig } from '../database/schema'
+import { USER_CONFIG_KEYS } from '../../src/shared/metadata'
+import {
+  CONNECTION_BEHAVIOR_SETTINGS_SCHEMA_VERSION,
+  buildDefaultConnectionBehaviorSettings,
+  normalizeConnectionBehaviorSettings,
+  type ConnectionBehaviorSettingsLoadResult,
+  type ConnectionBehaviorSettingsMigrateLegacyResult,
+  type ConnectionBehaviorSettingsPersistedV1,
+  type ConnectionBehaviorSettingsSavePayload,
+  type ConnectionBehaviorSettingsSaveResult,
+} from '../../src/shared/connectionBehaviorSettings'
+
+const STORAGE_KEY = USER_CONFIG_KEYS.connectionBehaviorSettingsV1
+
+type StoredConnectionBehaviorSettingsEnvelope = {
+  version: number
+  data: ConnectionBehaviorSettingsPersistedV1
+}
+
+type LegacyAdvancedSettings = {
+  autoConnect?: unknown
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return String(error)
+}
+
+function readPersistedEnvelope(): StoredConnectionBehaviorSettingsEnvelope | null {
+  const storedValue = getUserConfig(STORAGE_KEY)
+  if (!storedValue) {
+    return null
+  }
+
+  const parsed = JSON.parse(storedValue)
+  if (!isObject(parsed)) {
+    return null
+  }
+
+  return parsed as StoredConnectionBehaviorSettingsEnvelope
+}
+
+function readPersistedSettingsRecord(): {
+  exists: boolean
+  settings: ConnectionBehaviorSettingsPersistedV1
+} {
+  try {
+    const envelope = readPersistedEnvelope()
+    if (!envelope || envelope.version !== CONNECTION_BEHAVIOR_SETTINGS_SCHEMA_VERSION || !isObject(envelope.data)) {
+      return {
+        exists: false,
+        settings: buildDefaultConnectionBehaviorSettings(),
+      }
+    }
+
+    return {
+      exists: true,
+      settings: normalizeConnectionBehaviorSettings(envelope.data),
+    }
+  } catch (error) {
+    console.error('[ConnectionBehaviorSettingsService] 读取连接行为配置失败:', error)
+    return {
+      exists: false,
+      settings: buildDefaultConnectionBehaviorSettings(),
+    }
+  }
+}
+
+function writePersistedSettings(settings: ConnectionBehaviorSettingsPersistedV1): void {
+  const envelope: StoredConnectionBehaviorSettingsEnvelope = {
+    version: CONNECTION_BEHAVIOR_SETTINGS_SCHEMA_VERSION,
+    data: normalizeConnectionBehaviorSettings(settings),
+  }
+  setUserConfig(STORAGE_KEY, JSON.stringify(envelope))
+}
+
+function extractLegacyAutoConnect(rawLegacyJson: string): boolean {
+  if (!rawLegacyJson.trim()) {
+    return buildDefaultConnectionBehaviorSettings().autoConnectOnAppLaunch
+  }
+
+  try {
+    const parsed = JSON.parse(rawLegacyJson)
+    if (!isObject(parsed)) {
+      return buildDefaultConnectionBehaviorSettings().autoConnectOnAppLaunch
+    }
+
+    const legacy = parsed as LegacyAdvancedSettings
+    return typeof legacy.autoConnect === 'boolean'
+      ? legacy.autoConnect
+      : buildDefaultConnectionBehaviorSettings().autoConnectOnAppLaunch
+  } catch (error) {
+    console.error('[ConnectionBehaviorSettingsService] 解析旧版高级设置失败:', error)
+    return buildDefaultConnectionBehaviorSettings().autoConnectOnAppLaunch
+  }
+}
+
+export function loadConnectionBehaviorSettingsRecord(): {
+  exists: boolean
+  settings: ConnectionBehaviorSettingsPersistedV1
+} {
+  return readPersistedSettingsRecord()
+}
+
+export function loadConnectionBehaviorSettings(): ConnectionBehaviorSettingsLoadResult {
+  try {
+    const record = readPersistedSettingsRecord()
+    return {
+      success: true,
+      data: record.settings,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      code: 'PERSIST_FAILED',
+      message: `读取连接行为配置失败: ${toErrorMessage(error)}`,
+    }
+  }
+}
+
+export function saveConnectionBehaviorSettings(payload: ConnectionBehaviorSettingsSavePayload): ConnectionBehaviorSettingsSaveResult {
+  if (!isObject(payload) || !isObject(payload.data)) {
+    return {
+      success: false,
+      code: 'INVALID_PAYLOAD',
+      message: '连接行为配置请求体无效',
+    }
+  }
+
+  try {
+    const nextSettings = normalizeConnectionBehaviorSettings(payload.data)
+    writePersistedSettings(nextSettings)
+    return {
+      success: true,
+      data: nextSettings,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      code: 'PERSIST_FAILED',
+      message: `保存连接行为配置失败: ${toErrorMessage(error)}`,
+    }
+  }
+}
+
+export function migrateLegacyConnectionBehaviorSettings(rawLegacyJson: string): ConnectionBehaviorSettingsMigrateLegacyResult {
+  try {
+    const existing = readPersistedSettingsRecord()
+    if (existing.exists) {
+      return {
+        success: true,
+        data: existing.settings,
+      }
+    }
+
+    const defaults = buildDefaultConnectionBehaviorSettings()
+    const migrated = normalizeConnectionBehaviorSettings({
+      ...defaults,
+      autoConnectOnAppLaunch: extractLegacyAutoConnect(rawLegacyJson),
+    })
+    writePersistedSettings(migrated)
+
+    return {
+      success: true,
+      data: migrated,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      code: 'MIGRATION_FAILED',
+      message: `迁移旧版连接行为配置失败: ${toErrorMessage(error)}`,
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "screenshotQuality": "desktop_capture_quality",
         "screenshotMaxWidth": "desktop_capture_max_width",
         "connectionSettingsV3": "connection_settings_v3",
+        "connectionBehaviorSettingsV1": "connection_behavior_settings_v1",
         "alwaysOnTop": "tray_always_on_top",
         "fullPassThrough": "tray_pass_through_mode",
         "dynamicPassThrough": "desktop_dynamic_pass_through",

--- a/src/shared/bridgeConnectionValidation.ts
+++ b/src/shared/bridgeConnectionValidation.ts
@@ -1,0 +1,56 @@
+import type { BridgeLifecycleErrorCode } from './bridgeLifecycle'
+
+export type BridgeEndpointValidationResult =
+  | {
+      valid: true
+    }
+  | {
+      valid: false
+      code: BridgeLifecycleErrorCode
+      message: string
+    }
+
+export function validateBridgeEndpointDraft(input: {
+  serverUrl: string
+  token: string
+}): BridgeEndpointValidationResult {
+  const serverUrl = (input.serverUrl || '').trim()
+  const token = (input.token || '').trim()
+
+  if (!serverUrl) {
+    return {
+      valid: false,
+      code: 'INVALID_URL',
+      message: '服务器地址不能为空',
+    }
+  }
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(serverUrl)
+  } catch {
+    return {
+      valid: false,
+      code: 'INVALID_URL',
+      message: '服务器地址格式无效，请填写完整的 WebSocket 地址',
+    }
+  }
+
+  if (parsedUrl.protocol !== 'ws:' && parsedUrl.protocol !== 'wss:') {
+    return {
+      valid: false,
+      code: 'INVALID_URL',
+      message: '服务器地址必须使用 ws 或 wss 协议',
+    }
+  }
+
+  if (!token) {
+    return {
+      valid: false,
+      code: 'TOKEN_REQUIRED',
+      message: '认证密钥不能为空，请在设置中填写后再连接',
+    }
+  }
+
+  return { valid: true }
+}

--- a/src/shared/bridgeLifecycle.ts
+++ b/src/shared/bridgeLifecycle.ts
@@ -1,0 +1,92 @@
+import type { ConnectionSettingsEditable, ConnectionSettingsErrorCode } from './connectionSettings'
+
+export interface BridgeSessionState {
+  sessionId: string
+  userId: string
+  config: {
+    resourceBaseUrl?: string
+    resourcePath?: string
+    maxInlineBytes?: number
+  }
+}
+
+export type BridgeLifecycleStatus =
+  | 'idle'
+  | 'connecting'
+  | 'handshaking'
+  | 'connected'
+  | 'waiting_retry'
+  | 'suspended'
+  | 'error'
+
+export type BridgeDesiredState = 'connected' | 'disconnected'
+
+export type BridgeLifecycleErrorCode =
+  | 'INVALID_URL'
+  | 'TOKEN_REQUIRED'
+  | 'HANDSHAKE_TIMEOUT'
+  | 'AUTH_FAILED'
+  | 'VERSION_MISMATCH'
+  | 'WS_CONNECT_FAILED'
+  | 'WS_UNEXPECTED_CLOSE'
+  | 'CLIENT_UNAVAILABLE'
+  | 'UNKNOWN'
+
+export interface BridgeLifecycleSnapshot {
+  status: BridgeLifecycleStatus
+  desiredState: BridgeDesiredState
+  activeConfigRevision: number
+  serverUrl: string
+  hasToken: boolean
+  session: BridgeSessionState | null
+  reconnectAttempt: number
+  nextRetryAt: number | null
+  suspendReason: 'lock-screen' | 'suspend' | null
+  lastError: {
+    code: BridgeLifecycleErrorCode
+    message: string
+    retryable: boolean
+    at: number
+  } | null
+  lastDisconnect: {
+    source: 'manual' | 'socket-close' | 'socket-error' | 'system-suspend' | 'settings-changed'
+    code?: number
+    reason?: string
+    at: number
+  } | null
+  updatedAt: number
+}
+
+export interface BridgeLifecycleConnectRequest {
+  draftSettings?: ConnectionSettingsEditable
+  expectedRevision?: number
+}
+
+export type BridgeLifecycleCommandResult =
+  | {
+      success: true
+      snapshot: BridgeLifecycleSnapshot
+    }
+  | {
+      success: false
+      code: BridgeLifecycleErrorCode | ConnectionSettingsErrorCode
+      message: string
+      snapshot: BridgeLifecycleSnapshot
+    }
+
+export function buildDefaultBridgeLifecycleSnapshot(): BridgeLifecycleSnapshot {
+  return {
+    status: 'idle',
+    desiredState: 'disconnected',
+    activeConfigRevision: 0,
+    serverUrl: '',
+    hasToken: false,
+    session: null,
+    reconnectAttempt: 0,
+    nextRetryAt: null,
+    suspendReason: null,
+    lastError: null,
+    lastDisconnect: null,
+    updatedAt: Date.now(),
+  }
+}

--- a/src/shared/connectionBehaviorSettings.ts
+++ b/src/shared/connectionBehaviorSettings.ts
@@ -1,0 +1,137 @@
+export const CONNECTION_BEHAVIOR_SETTINGS_SCHEMA_VERSION = 1
+
+export type ConnectionBehaviorSettingsErrorCode =
+  | 'INVALID_PAYLOAD'
+  | 'PERSIST_FAILED'
+  | 'MIGRATION_FAILED'
+  | 'UNKNOWN'
+
+export interface ConnectionBehaviorSettingsPersistedV1 {
+  autoConnectOnAppLaunch: boolean
+  resumeDesiredConnectionOnWake: boolean
+  retryEnabled: boolean
+  retryBaseDelayMs: number
+  retryMaxDelayMs: number
+  retryMaxAttempts: number | null
+  handshakeTimeoutMs: number
+}
+
+export interface ConnectionBehaviorSettingsChangedEvent {
+  settings: ConnectionBehaviorSettingsPersistedV1
+  sourceWindowId?: number
+}
+
+export interface ConnectionBehaviorSettingsSavePayload {
+  data: ConnectionBehaviorSettingsPersistedV1
+}
+
+export type ConnectionBehaviorSettingsLoadResult =
+  | {
+      success: true
+      data: ConnectionBehaviorSettingsPersistedV1
+    }
+  | {
+      success: false
+      code: ConnectionBehaviorSettingsErrorCode
+      message: string
+    }
+
+export type ConnectionBehaviorSettingsSaveResult =
+  | {
+      success: true
+      data: ConnectionBehaviorSettingsPersistedV1
+    }
+  | {
+      success: false
+      code: ConnectionBehaviorSettingsErrorCode
+      message: string
+    }
+
+export type ConnectionBehaviorSettingsMigrateLegacyResult =
+  | {
+      success: true
+      data: ConnectionBehaviorSettingsPersistedV1
+    }
+  | {
+      success: false
+      code: ConnectionBehaviorSettingsErrorCode
+      message: string
+    }
+
+const MIN_RETRY_DELAY_MS = 250
+const MAX_RETRY_DELAY_MS = 300000
+const MIN_RETRY_ATTEMPTS = 1
+const MAX_RETRY_ATTEMPTS = 1000
+const MIN_HANDSHAKE_TIMEOUT_MS = 1000
+const MAX_HANDSHAKE_TIMEOUT_MS = 60000
+
+export function buildDefaultConnectionBehaviorSettings(): ConnectionBehaviorSettingsPersistedV1 {
+  return {
+    autoConnectOnAppLaunch: true,
+    resumeDesiredConnectionOnWake: true,
+    retryEnabled: true,
+    retryBaseDelayMs: 1000,
+    retryMaxDelayMs: 30000,
+    retryMaxAttempts: null,
+    handshakeTimeoutMs: 8000,
+  }
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function normalizeRetryDelay(value: unknown, fallback: number): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+  return Math.max(MIN_RETRY_DELAY_MS, Math.min(MAX_RETRY_DELAY_MS, Math.round(numeric)))
+}
+
+function normalizeRetryAttempts(value: unknown, fallback: number | null): number | null {
+  if (value === null) {
+    return null
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+
+  return Math.max(MIN_RETRY_ATTEMPTS, Math.min(MAX_RETRY_ATTEMPTS, Math.round(numeric)))
+}
+
+function normalizeHandshakeTimeout(value: unknown, fallback: number): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+  return Math.max(MIN_HANDSHAKE_TIMEOUT_MS, Math.min(MAX_HANDSHAKE_TIMEOUT_MS, Math.round(numeric)))
+}
+
+export function normalizeConnectionBehaviorSettings(
+  value: Partial<ConnectionBehaviorSettingsPersistedV1> | null | undefined,
+): ConnectionBehaviorSettingsPersistedV1 {
+  const defaults = buildDefaultConnectionBehaviorSettings()
+  const source = value || {}
+
+  const retryBaseDelayMs = normalizeRetryDelay(source.retryBaseDelayMs, defaults.retryBaseDelayMs)
+  const retryMaxDelayMs = Math.max(
+    retryBaseDelayMs,
+    normalizeRetryDelay(source.retryMaxDelayMs, defaults.retryMaxDelayMs),
+  )
+
+  return {
+    autoConnectOnAppLaunch: normalizeBoolean(source.autoConnectOnAppLaunch, defaults.autoConnectOnAppLaunch),
+    resumeDesiredConnectionOnWake: normalizeBoolean(
+      source.resumeDesiredConnectionOnWake,
+      defaults.resumeDesiredConnectionOnWake,
+    ),
+    retryEnabled: normalizeBoolean(source.retryEnabled, defaults.retryEnabled),
+    retryBaseDelayMs,
+    retryMaxDelayMs,
+    retryMaxAttempts: normalizeRetryAttempts(source.retryMaxAttempts, defaults.retryMaxAttempts),
+    handshakeTimeoutMs: normalizeHandshakeTimeout(source.handshakeTimeoutMs, defaults.handshakeTimeoutMs),
+  }
+}

--- a/src/stores/connection.ts
+++ b/src/stores/connection.ts
@@ -3,12 +3,17 @@ import { computed, ref } from 'vue'
 import type { InputMessagePayload, MessageContent } from '@/types/protocol'
 import { LOCAL_STORAGE_METADATA } from '@/shared/metadata'
 import {
+  buildDefaultBridgeLifecycleSnapshot,
+  type BridgeLifecycleSnapshot,
+} from '@/shared/bridgeLifecycle'
+import {
   buildDefaultConnectionSettingsEditable,
   normalizeConnectionSettingsEditable,
   type ConnectionSettingsEditable,
   type ConnectionSettingsPersistedV3,
 } from '@/shared/connectionSettings'
 import { deriveHttpBaseUrlFromWsUrl } from '@/utils/urlNormalize'
+import { ADVANCED_SETTINGS_KEY } from '@/utils/advancedSettings'
 
 const DEFAULT_RESOURCE_PATH = '/resources'
 const LEGACY_CONNECTION_SETTINGS_KEY = LOCAL_STORAGE_METADATA.connectionSettings.key
@@ -32,22 +37,6 @@ function buildRendererPreferredDefaults(): ConnectionSettingsEditable {
   return defaults
 }
 
-function getBridgeUrlValidationError(rawUrl: string): string | null {
-  let parsedUrl: URL
-
-  try {
-    parsedUrl = new URL(rawUrl)
-  } catch {
-    return '服务器地址格式无效，请填写完整的 WebSocket 地址'
-  }
-
-  if (parsedUrl.protocol !== 'ws:' && parsedUrl.protocol !== 'wss:') {
-    return '服务器地址必须使用 ws 或 wss 协议'
-  }
-
-  return null
-}
-
 function buildDefaultPersistedSettings(): ConnectionSettingsPersistedV3 {
   const defaults = buildDefaultConnectionSettingsEditable()
   return {
@@ -57,92 +46,70 @@ function buildDefaultPersistedSettings(): ConnectionSettingsPersistedV3 {
   }
 }
 
-function toPersistPayload(data: ConnectionSettingsEditable, expectedRevision: number) {
-  return {
-    data: normalizeConnectionSettingsEditable(data),
-    expectedRevision,
-  }
-}
-
-function isSameEditableSettings(a: ConnectionSettingsEditable, b: ConnectionSettingsEditable): boolean {
-  return a.serverUrl === b.serverUrl
-    && a.token === b.token
-    && a.customResourceBaseUrl === b.customResourceBaseUrl
-    && a.customResourcePath === b.customResourcePath
-    && a.customResourceToken === b.customResourceToken
-}
-
 export const useConnectionStore = defineStore('connection', () => {
-  const defaults = buildRendererPreferredDefaults()
-
-  const isConnected = ref(false)
-  const sessionId = ref('')
-  const userId = ref('')
-  const sessionResourceBaseUrl = ref('')
-  const sessionResourcePath = ref('')
-  const maxInlineBytes = ref<number | null>(null)
-
-  const serverUrl = ref(defaults.serverUrl)
-  const token = ref(defaults.token)
-  const customResourceBaseUrl = ref(defaults.customResourceBaseUrl)
-  const customResourcePath = ref(defaults.customResourcePath)
-  const customResourceToken = ref(defaults.customResourceToken)
-  const persistedSnapshot = ref<ConnectionSettingsEditable>(normalizeConnectionSettingsEditable(defaults))
-
-  const persistedRevision = ref(0)
-  const persistedUpdatedAt = ref(0)
+  const persistedSettings = ref<ConnectionSettingsPersistedV3>(buildDefaultPersistedSettings())
+  const lifecycleSnapshot = ref<BridgeLifecycleSnapshot>(buildDefaultBridgeLifecycleSnapshot())
 
   let initialized = false
   let initializePromise: Promise<void> | null = null
-  let settingsSyncBound = false
-  let settingsSyncDisposer: Unsubscribe | null = null
+  let syncBound = false
+  let lifecycleSnapshotHydrated = false
+  let settingsDisposer: Unsubscribe | null = null
+  let lifecycleDisposer: Unsubscribe | null = null
+
+  const serverUrl = computed(() => persistedSettings.value.serverUrl)
+  const token = computed(() => persistedSettings.value.token)
+  const customResourceBaseUrl = computed(() => persistedSettings.value.customResourceBaseUrl)
+  const customResourcePath = computed(() => persistedSettings.value.customResourcePath)
+  const customResourceToken = computed(() => persistedSettings.value.customResourceToken)
+  const persistedRevision = computed(() => persistedSettings.value.revision)
+  const persistedUpdatedAt = computed(() => persistedSettings.value.updatedAt)
+
+  const lifecycleStatus = computed(() => lifecycleSnapshot.value.status)
+  const desiredState = computed(() => lifecycleSnapshot.value.desiredState)
+  const isConnected = computed(() => lifecycleSnapshot.value.status === 'connected')
+  const sessionId = computed(() => lifecycleSnapshot.value.session?.sessionId || '')
+  const userId = computed(() => lifecycleSnapshot.value.session?.userId || '')
+  const maxInlineBytes = computed(() => {
+    const value = lifecycleSnapshot.value.session?.config?.maxInlineBytes
+    return typeof value === 'number' ? value : null
+  })
+  const nextRetryAt = computed(() => lifecycleSnapshot.value.nextRetryAt)
+  const reconnectAttempt = computed(() => lifecycleSnapshot.value.reconnectAttempt)
+  const lastError = computed(() => lifecycleSnapshot.value.lastError)
 
   const resourceBaseUrl = computed(() => {
-    const overrideValue = customResourceBaseUrl.value.trim()
+    const overrideValue = persistedSettings.value.customResourceBaseUrl.trim()
     if (overrideValue) {
       return overrideValue
     }
 
-    const sessionValue = sessionResourceBaseUrl.value.trim()
+    const sessionValue = lifecycleSnapshot.value.session?.config?.resourceBaseUrl?.trim() || ''
     if (sessionValue) {
       return sessionValue
     }
 
-    return deriveHttpBaseUrlFromWsUrl(serverUrl.value)
+    return deriveHttpBaseUrlFromWsUrl(persistedSettings.value.serverUrl)
   })
 
   const resourcePath = computed(() => {
-    const overrideValue = customResourcePath.value.trim()
+    const overrideValue = persistedSettings.value.customResourcePath.trim()
     if (overrideValue) {
       return overrideValue
     }
 
-    const sessionValue = sessionResourcePath.value.trim()
+    const sessionValue = lifecycleSnapshot.value.session?.config?.resourcePath?.trim() || ''
     return sessionValue || DEFAULT_RESOURCE_PATH
   })
 
   const resourceToken = computed(() => {
-    const overrideValue = customResourceToken.value.trim()
+    const overrideValue = persistedSettings.value.customResourceToken.trim()
     if (overrideValue) {
       return overrideValue
     }
 
-    return token.value.trim()
+    return persistedSettings.value.token.trim()
   })
-
-  const hasUnsavedChanges = computed(() => {
-    return !isSameEditableSettings(collectEditableSettings(), persistedSnapshot.value)
-  })
-
-  function collectEditableSettings(): ConnectionSettingsEditable {
-    return normalizeConnectionSettingsEditable({
-      serverUrl: serverUrl.value,
-      token: token.value,
-      customResourceBaseUrl: customResourceBaseUrl.value,
-      customResourcePath: customResourcePath.value,
-      customResourceToken: customResourceToken.value,
-    })
-  }
 
   function applyPersistedSettings(settings: ConnectionSettingsPersistedV3) {
     const baselineDefaults = buildDefaultConnectionSettingsEditable()
@@ -158,17 +125,27 @@ export const useConnectionStore = defineStore('connection', () => {
         })
       : baseEditable
 
-    serverUrl.value = editable.serverUrl
-    token.value = editable.token
-    customResourceBaseUrl.value = editable.customResourceBaseUrl
-    customResourcePath.value = editable.customResourcePath
-    customResourceToken.value = editable.customResourceToken
-    persistedSnapshot.value = editable
-    persistedRevision.value = settings.revision
-    persistedUpdatedAt.value = settings.updatedAt
+    persistedSettings.value = {
+      ...editable,
+      revision: settings.revision,
+      updatedAt: settings.updatedAt,
+    }
   }
 
-  async function migrateLegacySettingsIfNeeded() {
+  function applyLifecycleSnapshot(snapshot: BridgeLifecycleSnapshot | null | undefined) {
+    if (!snapshot) {
+      return
+    }
+
+    if (lifecycleSnapshotHydrated && snapshot.updatedAt < lifecycleSnapshot.value.updatedAt) {
+      return
+    }
+
+    lifecycleSnapshot.value = snapshot
+    lifecycleSnapshotHydrated = true
+  }
+
+  async function migrateLegacyConnectionSettingsIfNeeded() {
     if (typeof window === 'undefined') {
       return
     }
@@ -192,6 +169,22 @@ export const useConnectionStore = defineStore('connection', () => {
     }
   }
 
+  async function migrateLegacyBehaviorSettingsIfNeeded() {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      const legacyRaw = localStorage.getItem(ADVANCED_SETTINGS_KEY) || ''
+      const migrateResult = await window.electron.connectionBehaviorSettings.migrateLegacy(legacyRaw)
+      if (!migrateResult.success) {
+        console.warn('[ConnectionStore] 迁移旧连接行为配置失败:', migrateResult.code, migrateResult.message)
+      }
+    } catch (error) {
+      console.warn('[ConnectionStore] 迁移旧连接行为配置异常:', error)
+    }
+  }
+
   async function reloadPersistedSettings() {
     const loadResult = await window.electron.connectionSettings.load()
     if (loadResult.success) {
@@ -204,6 +197,48 @@ export const useConnectionStore = defineStore('connection', () => {
     return { success: false as const, code: loadResult.code, error: loadResult.message }
   }
 
+  async function refreshLifecycleSnapshot() {
+    const snapshot = await window.electron.bridgeLifecycle.getSnapshot()
+    applyLifecycleSnapshot(snapshot)
+    return snapshot
+  }
+
+  function startSync() {
+    if (
+      syncBound
+      || typeof window === 'undefined'
+      || !window.electron?.connectionSettings
+      || !window.electron?.bridgeLifecycle
+    ) {
+      return
+    }
+
+    settingsDisposer = window.electron.connectionSettings.onChanged((event) => {
+      if (!event?.settings) {
+        return
+      }
+      applyPersistedSettings(event.settings)
+    })
+
+    lifecycleDisposer = window.electron.bridgeLifecycle.onStateChanged((snapshot) => {
+      applyLifecycleSnapshot(snapshot)
+    })
+
+    syncBound = true
+  }
+
+  function stopSync() {
+    if (!syncBound) {
+      return
+    }
+
+    settingsDisposer?.()
+    lifecycleDisposer?.()
+    settingsDisposer = null
+    lifecycleDisposer = null
+    syncBound = false
+  }
+
   async function ensureInitialized() {
     if (initialized) {
       return
@@ -214,189 +249,19 @@ export const useConnectionStore = defineStore('connection', () => {
     }
 
     initializePromise = (async () => {
-      await migrateLegacySettingsIfNeeded()
-      await reloadPersistedSettings()
+      startSync()
+      await migrateLegacyConnectionSettingsIfNeeded()
+      await migrateLegacyBehaviorSettingsIfNeeded()
+      await Promise.all([
+        reloadPersistedSettings(),
+        refreshLifecycleSnapshot(),
+      ])
       initialized = true
     })().finally(() => {
       initializePromise = null
     })
 
     return initializePromise
-  }
-
-  function applySessionState(session: BridgeSessionState | null | undefined) {
-    sessionId.value = session?.sessionId || ''
-    userId.value = session?.userId || ''
-
-    if (session?.config?.resourceBaseUrl) {
-      sessionResourceBaseUrl.value = session.config.resourceBaseUrl
-    } else if (!session) {
-      sessionResourceBaseUrl.value = ''
-    }
-
-    if (session?.config?.resourcePath) {
-      sessionResourcePath.value = session.config.resourcePath
-    } else if (!session) {
-      sessionResourcePath.value = ''
-    }
-
-    maxInlineBytes.value = typeof session?.config?.maxInlineBytes === 'number'
-      ? session.config.maxInlineBytes
-      : null
-  }
-
-  function resetSessionState() {
-    isConnected.value = false
-    sessionId.value = ''
-    userId.value = ''
-    sessionResourceBaseUrl.value = ''
-    sessionResourcePath.value = ''
-    maxInlineBytes.value = null
-  }
-
-  function setConnectionConfig(url: string, authToken: string) {
-    serverUrl.value = (url || '').trim() || defaults.serverUrl
-    token.value = (authToken || '').trim()
-  }
-
-  function setResourceConfig(baseUrl: string, path: string, accessToken: string) {
-    customResourceBaseUrl.value = (baseUrl || '').trim()
-    customResourcePath.value = (path || '').trim()
-    customResourceToken.value = (accessToken || '').trim()
-  }
-
-  async function savePersistedSettings() {
-    await ensureInitialized()
-    const saveResult = await window.electron.connectionSettings.save(
-      toPersistPayload(collectEditableSettings(), persistedRevision.value),
-    )
-
-    if (saveResult.success) {
-      applyPersistedSettings(saveResult.data)
-      return { success: true as const }
-    }
-
-    if (saveResult.code === 'CONFLICT_REVISION') {
-      await reloadPersistedSettings()
-      return {
-        success: false as const,
-        code: saveResult.code,
-        error: '连接配置已被其他窗口更新，当前表单已刷新为最新值，请确认后重试保存',
-      }
-    }
-
-    return {
-      success: false as const,
-      code: saveResult.code,
-      error: saveResult.message,
-    }
-  }
-
-  async function connect(url?: string, authToken?: string) {
-    await ensureInitialized()
-
-    try {
-      const targetUrl = (url || serverUrl.value || '').trim()
-      const normalizedToken = (authToken ?? token.value ?? '').trim()
-
-      if (!targetUrl) {
-        return { success: false, error: '服务器地址不能为空' }
-      }
-
-      const urlValidationError = getBridgeUrlValidationError(targetUrl)
-      if (urlValidationError) {
-        return { success: false, error: urlValidationError }
-      }
-
-      if (!normalizedToken) {
-        return { success: false, error: '认证密钥不能为空，请在设置中填写后再连接' }
-      }
-      if (normalizedToken.length < 16) {
-        return { success: false, error: '认证密钥长度至少 16 位' }
-      }
-
-      setConnectionConfig(targetUrl, normalizedToken)
-      const saveResult = await savePersistedSettings()
-      if (!saveResult.success) {
-        return { success: false, error: saveResult.error }
-      }
-
-      const result = await window.electron.bridge.connect(targetUrl, normalizedToken)
-      if (result.success) {
-        isConnected.value = true
-        const session = await window.electron.bridge.getSession()
-        applySessionState(session)
-        return { success: true }
-      }
-
-      return { success: false, error: result.error }
-    } catch (error: any) {
-      return { success: false, error: error.message }
-    }
-  }
-
-  async function disconnect() {
-    try {
-      await window.electron.bridge.disconnect()
-      resetSessionState()
-      return { success: true }
-    } catch (error: any) {
-      return { success: false, error: error.message }
-    }
-  }
-
-  async function checkConnection() {
-    await ensureInitialized()
-
-    const connected = await window.electron.bridge.isConnected()
-    isConnected.value = connected
-
-    if (connected) {
-      const session = await window.electron.bridge.getSession()
-      applySessionState(session)
-    } else {
-      applySessionState(null)
-    }
-
-    return connected
-  }
-
-  function handleConnected(session: BridgeSessionState | null | undefined) {
-    isConnected.value = true
-    applySessionState(session)
-  }
-
-  function handleDisconnected() {
-    resetSessionState()
-  }
-
-  function startStorageSync() {
-    if (
-      settingsSyncBound
-      || typeof window === 'undefined'
-      || !window.electron?.connectionSettings
-    ) {
-      return
-    }
-
-    settingsSyncDisposer = window.electron.connectionSettings.onChanged((event) => {
-      if (!event?.settings) {
-        return
-      }
-      applyPersistedSettings(event.settings)
-    })
-
-    settingsSyncBound = true
-  }
-
-  function stopStorageSync() {
-    if (!settingsSyncBound) {
-      return
-    }
-
-    settingsSyncDisposer?.()
-    settingsSyncDisposer = null
-    settingsSyncBound = false
   }
 
   async function sendMessage(content: MessageContent[], metadata: InputMessagePayload['metadata']) {
@@ -408,36 +273,33 @@ export const useConnectionStore = defineStore('connection', () => {
   }
 
   return {
-    isConnected,
-    sessionId,
-    userId,
-    resourceBaseUrl,
-    resourcePath,
-    resourceToken,
-    maxInlineBytes,
-    serverUrl,
-    token,
     customResourceBaseUrl,
     customResourcePath,
     customResourceToken,
-    hasUnsavedChanges,
+    desiredState,
+    ensureInitialized,
+    isConnected,
+    lastError,
+    lifecycleSnapshot,
+    lifecycleStatus,
+    maxInlineBytes,
+    nextRetryAt,
     persistedRevision,
+    persistedSettings,
     persistedUpdatedAt,
-    applySessionState,
-    resetSessionState,
-    setConnectionConfig,
-    setResourceConfig,
-    savePersistedSettings,
+    reconnectAttempt,
+    refreshLifecycleSnapshot,
     reloadPersistedSettings,
-    startStorageSync,
-    stopStorageSync,
-    handleConnected,
-    handleDisconnected,
-    connect,
-    disconnect,
-    checkConnection,
+    resourceBaseUrl,
+    resourcePath,
+    resourceToken,
     sendMessage,
     sendState,
-    ensureInitialized,
+    serverUrl,
+    sessionId,
+    startSync,
+    stopSync,
+    token,
+    userId,
   }
 })

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -16,6 +16,19 @@ import type {
   DesktopRevealReason as _DesktopRevealReason,
 } from '../../electron/desktopBehavior/types'
 import type {
+  BridgeLifecycleCommandResult as _BridgeLifecycleCommandResult,
+  BridgeLifecycleSnapshot as _BridgeLifecycleSnapshot,
+  BridgeSessionState as _BridgeSessionState,
+} from '../shared/bridgeLifecycle'
+import type {
+  ConnectionBehaviorSettingsChangedEvent as _ConnectionBehaviorSettingsChangedEvent,
+  ConnectionBehaviorSettingsLoadResult as _ConnectionBehaviorSettingsLoadResult,
+  ConnectionBehaviorSettingsMigrateLegacyResult as _ConnectionBehaviorSettingsMigrateLegacyResult,
+  ConnectionBehaviorSettingsSavePayload as _ConnectionBehaviorSettingsSavePayload,
+  ConnectionBehaviorSettingsSaveResult as _ConnectionBehaviorSettingsSaveResult,
+  ConnectionBehaviorSettingsPersistedV1 as _ConnectionBehaviorSettingsPersistedV1,
+} from '../shared/connectionBehaviorSettings'
+import type {
   ConnectionSettingsChangedEvent as _ConnectionSettingsChangedEvent,
   ConnectionSettingsLoadResult as _ConnectionSettingsLoadResult,
   ConnectionSettingsMigrateLegacyResult as _ConnectionSettingsMigrateLegacyResult,
@@ -43,6 +56,15 @@ declare global {
   type DesktopBehaviorRuntimeState = _DesktopBehaviorRuntimeState
   type DesktopBehaviorSnapshot = _DesktopBehaviorSnapshot
   type DesktopRevealReason = _DesktopRevealReason
+  type BridgeLifecycleCommandResult = _BridgeLifecycleCommandResult
+  type BridgeLifecycleSnapshot = _BridgeLifecycleSnapshot
+  type BridgeSessionState = _BridgeSessionState
+  type ConnectionBehaviorSettingsChangedEvent = _ConnectionBehaviorSettingsChangedEvent
+  type ConnectionBehaviorSettingsLoadResult = _ConnectionBehaviorSettingsLoadResult
+  type ConnectionBehaviorSettingsSavePayload = _ConnectionBehaviorSettingsSavePayload
+  type ConnectionBehaviorSettingsSaveResult = _ConnectionBehaviorSettingsSaveResult
+  type ConnectionBehaviorSettingsMigrateLegacyResult = _ConnectionBehaviorSettingsMigrateLegacyResult
+  type ConnectionBehaviorSettingsPersistedV1 = _ConnectionBehaviorSettingsPersistedV1
   type ConnectionSettingsChangedEvent = _ConnectionSettingsChangedEvent
   type ConnectionSettingsLoadResult = _ConnectionSettingsLoadResult
   type ConnectionSettingsSavePayload = _ConnectionSettingsSavePayload
@@ -52,15 +74,6 @@ declare global {
   type HistoryMessageRecord = _HistoryMessageRecord
   type HistoryGetMessagesResult = _HistoryGetMessagesResult
   type HistorySaveMessageResult = _HistorySaveMessageResult
-  interface BridgeSessionState {
-    sessionId: string
-    userId: string
-    config: {
-      resourceBaseUrl?: string
-      resourcePath?: string
-      maxInlineBytes?: number
-    }
-  }
 
   interface UpdateState {
     status: 'disabled' | 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
@@ -92,18 +105,18 @@ declare global {
   interface Window {
     electron: {
       bridge: {
-        connect: (url: string, token?: string) => Promise<{ success: boolean; error?: string }>
-        disconnect: () => Promise<{ success: boolean; error?: string }>
-        isConnected: () => Promise<boolean>
         getSession: () => Promise<BridgeSessionState | null>
         sendMessage: (payload: any) => Promise<{ success: boolean; error?: string; content?: any[] }>
         sendTouch: (x: number, y: number, action: string) => Promise<{ success: boolean; error?: string }>
         sendState: (op: string, payload: any) => Promise<{ success: boolean; error?: string }>
-        onConnected: (callback: (payload: any) => void) => Unsubscribe
-        onDisconnected: (callback: (info: any) => void) => Unsubscribe
-        onError: (callback: (error: any) => void) => Unsubscribe
         onPerformShow: (callback: (payload: any) => void) => Unsubscribe
         onPerformInterrupt: (callback: () => void) => Unsubscribe
+      }
+      bridgeLifecycle: {
+        getSnapshot: () => Promise<BridgeLifecycleSnapshot>
+        connect: () => Promise<BridgeLifecycleCommandResult>
+        disconnect: () => Promise<BridgeLifecycleCommandResult>
+        onStateChanged: (callback: (snapshot: BridgeLifecycleSnapshot) => void) => Unsubscribe
       }
       window: {
         openSettings: (page?: string) => Promise<{ success: boolean }>
@@ -162,6 +175,12 @@ declare global {
         save: (payload: ConnectionSettingsSavePayload) => Promise<ConnectionSettingsSaveResult>
         migrateLegacy: (rawLegacyJson: string) => Promise<ConnectionSettingsMigrateLegacyResult>
         onChanged: (callback: (event: ConnectionSettingsChangedEvent) => void) => Unsubscribe
+      }
+      connectionBehaviorSettings: {
+        load: () => Promise<ConnectionBehaviorSettingsLoadResult>
+        save: (payload: ConnectionBehaviorSettingsSavePayload) => Promise<ConnectionBehaviorSettingsSaveResult>
+        migrateLegacy: (rawLegacyJson: string) => Promise<ConnectionBehaviorSettingsMigrateLegacyResult>
+        onChanged: (callback: (event: ConnectionBehaviorSettingsChangedEvent) => void) => Unsubscribe
       }
       history: {
         getMessages: (options: HistoryMessageQueryOptions) => Promise<HistoryGetMessagesResult>

--- a/src/utils/advancedSettings.ts
+++ b/src/utils/advancedSettings.ts
@@ -18,7 +18,6 @@ export type AppLogLevel = 'info' | 'debug'
 
 export interface AdvancedSettings {
   recordingShortcut: string
-  autoConnect: boolean
   autoLoadLastModel: boolean
   themeFollowModel: boolean
   lipSyncEnabled: boolean
@@ -34,7 +33,6 @@ export interface AdvancedSettings {
 
 export const DEFAULT_ADVANCED_SETTINGS: AdvancedSettings = {
   recordingShortcut: 'Alt+R',
-  autoConnect: true,
   autoLoadLastModel: true,
   themeFollowModel: true,
   lipSyncEnabled: true,
@@ -73,9 +71,6 @@ export function normalizeAdvancedSettings(value: unknown): AdvancedSettings {
     recordingShortcut: typeof raw.recordingShortcut === 'string'
       ? raw.recordingShortcut
       : DEFAULT_ADVANCED_SETTINGS.recordingShortcut,
-    autoConnect: typeof raw.autoConnect === 'boolean'
-      ? raw.autoConnect
-      : DEFAULT_ADVANCED_SETTINGS.autoConnect,
     autoLoadLastModel: typeof raw.autoLoadLastModel === 'boolean'
       ? raw.autoLoadLastModel
       : DEFAULT_ADVANCED_SETTINGS.autoLoadLastModel,

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -240,6 +240,13 @@ const connectionStore = useConnectionStore()
 const modelStore = useModelStore()
 const themeStore = useThemeStore()
 const { sourceRgb } = storeToRefs(themeStore)
+const {
+  desiredState,
+  lastError,
+  lifecycleStatus,
+  nextRetryAt,
+  reconnectAttempt,
+} = storeToRefs(connectionStore)
 
 const live2dCanvasRef = ref<InstanceType<typeof Live2DCanvas> | null>(null)
 const mediaPlayerRef = ref<InstanceType<typeof MediaPlayer>>()
@@ -849,6 +856,49 @@ function handleStorageChange(event: StorageEvent) {
   }
 }
 
+function formatRetryHint(): string {
+  if (!nextRetryAt.value) {
+    return '连接已断开，等待自动重试'
+  }
+
+  const seconds = Math.max(1, Math.ceil((nextRetryAt.value - Date.now()) / 1000))
+  return `连接已断开，${seconds} 秒后自动重试（第 ${reconnectAttempt.value} 次）`
+}
+
+watch(lifecycleStatus, (status, previousStatus) => {
+  if (status === 'connected' && previousStatus !== 'connected') {
+    showBaseEventStatus('已连接到服务器', 'success')
+    return
+  }
+
+  if (status === 'waiting_retry') {
+    showBaseEventStatus(formatRetryHint(), 'warning', 3600)
+    return
+  }
+
+  if (status === 'suspended') {
+    showBaseEventStatus('系统挂起，连接已暂停', 'info', 3600)
+    return
+  }
+
+  if (
+    status === 'idle'
+    && previousStatus
+    && previousStatus !== 'idle'
+    && desiredState.value === 'disconnected'
+  ) {
+    showBaseEventStatus('已断开连接', 'warning')
+  }
+})
+
+watch(lastError, (error, previousError) => {
+  if (!error || error.at === previousError?.at) {
+    return
+  }
+
+  showModelStatus(`连接错误: ${error.message}`, 'error', 4200)
+})
+
 function handleAudioStart(audioElement: HTMLAudioElement) {
   console.log('[主窗口] 音频开始播放，启动口型同步')
   if (!advancedSettings.value.lipSyncEnabled) {
@@ -865,6 +915,8 @@ function handleAudioEnd() {
 
 // 监听表演指令
 onMounted(async () => {
+  await connectionStore.ensureInitialized()
+
   // 获取用户名称
   try {
     const name = await window.electron.user.getUserName()
@@ -877,7 +929,6 @@ onMounted(async () => {
 
   // 监听全局快捷键录音
   initializeAdvancedSettingsForSession()
-  connectionStore.startStorageSync()
   modelStore.startStorageSync()
   window.addEventListener('storage', handleStorageChange)
   window.addEventListener('resize', updateUIPositions)
@@ -1074,39 +1125,6 @@ onMounted(async () => {
     interruptPerformance()
   }))
 
-  mainWindowDisposers.push(window.electron.bridge.onConnected((payload: BridgeSessionState) => {
-    showBaseEventStatus('已连接到服务器', 'success')
-    console.log('连接信息:', payload)
-
-    connectionStore.handleConnected(payload)
-  }))
-
-  mainWindowDisposers.push(window.electron.bridge.onDisconnected((info: unknown) => {
-    showBaseEventStatus('已断开连接', 'warning')
-    console.log('断开信息:', info)
-
-    connectionStore.handleDisconnected()
-  }))
-
-  mainWindowDisposers.push(window.electron.bridge.onError((error: { message?: string } | string) => {
-    const errorMessage = typeof error === 'string' ? error : (error.message || '未知错误')
-    showModelStatus(`连接错误: ${errorMessage}`, 'error')
-  }))
-
-  // 检查初始连接状态
-  await connectionStore.checkConnection()
-
-  // 自动连接功能
-  if (advancedSettings.value.autoConnect && !connectionStore.isConnected) {
-    console.log('[Main] Auto connect on startup')
-    const result = await connectionStore.connect()
-    if (result.success) {
-      console.log('[Main] Auto connect success')
-    } else {
-      console.warn('[Main] Auto connect failed:', result.error)
-    }
-  }
-
   const lastModelPath = modelStore.getLastModel()
   if (advancedSettings.value.autoLoadLastModel && lastModelPath) {
     console.log('[主窗口] 自动加载上次模型:', lastModelPath)
@@ -1147,7 +1165,7 @@ onBeforeUnmount(() => {
   }
   window.removeEventListener('storage', handleStorageChange)
   window.removeEventListener('resize', updateUIPositions)
-  connectionStore.stopStorageSync()
+  connectionStore.stopSync()
   modelStore.stopStorageSync()
   cleanupBubbleStack()
   releaseAllAudioWaiters()

--- a/src/windows/Settings.vue
+++ b/src/windows/Settings.vue
@@ -141,6 +141,7 @@ const navigationReady = ref(false)
 const settingsWindowDisposers: Unsubscribe[] = []
 
 onMounted(async () => {
+  await connectionStore.ensureInitialized()
   modelStore.startStorageSync()
 
   if (window.electron.settings?.onNavigateTo) {
@@ -172,22 +173,18 @@ onMounted(async () => {
   }))
 
   settingsWindowDisposers.push(window.electron.connectionSettings.onChanged(async () => {
-    if (connectionDomain.hasUnsavedConnectionSettings.value) {
-      message.warning('检测到其他窗口更新了连接配置，请先保存或放弃当前修改后再同步')
-      return
-    }
-
-    await connectionStore.reloadPersistedSettings()
+    await connectionDomain.handleExternalSettingsChanged()
     await historyDomain.syncResourceConfig(true)
   }))
 
-  settingsWindowDisposers.push(window.electron.bridge.onConnected((payload: BridgeSessionState) => {
-    connectionStore.handleConnected(payload)
-    void historyDomain.syncResourceConfig(true)
+  settingsWindowDisposers.push(window.electron.connectionBehaviorSettings.onChanged((event) => {
+    if (!event?.settings) {
+      return
+    }
+    advancedDomain.applyConnectionBehaviorSettingsState(event.settings)
   }))
 
-  settingsWindowDisposers.push(window.electron.bridge.onDisconnected(() => {
-    connectionStore.handleDisconnected()
+  settingsWindowDisposers.push(window.electron.bridgeLifecycle.onStateChanged(() => {
     void historyDomain.syncResourceConfig(true)
   }))
 

--- a/src/windows/settings/domains/createAdvancedSettingsDomain.ts
+++ b/src/windows/settings/domains/createAdvancedSettingsDomain.ts
@@ -17,6 +17,11 @@ import {
   saveAdvancedSettings as persistAdvancedSettings,
 } from '@/utils/advancedSettings'
 import {
+  buildDefaultConnectionBehaviorSettings,
+  normalizeConnectionBehaviorSettings,
+  type ConnectionBehaviorSettingsPersistedV1,
+} from '@/shared/connectionBehaviorSettings'
+import {
   DEFAULT_DESKTOP_FEATURE_SETTINGS,
   type DesktopFeatureSettings,
 } from '@/utils/desktopFeatureSettings'
@@ -29,9 +34,11 @@ import { createDeferredTaskCache } from '../composables/createDeferredTaskCache'
 export interface AdvancedSettingsDomain {
   advancedSettings: Ref<AdvancedSettings>
   alwaysOnTopLevelLabel: ComputedRef<string>
+  applyConnectionBehaviorSettingsState: (settings: ConnectionBehaviorSettingsPersistedV1) => void
   applyDesktopFeatureSettingsState: (settings: DesktopFeatureSettings) => void
   applyAdvancedSettingChange: () => Promise<void>
   checkShortcutRegistration: (force?: boolean) => Promise<void>
+  connectionBehaviorSettings: Ref<ConnectionBehaviorSettingsPersistedV1>
   desktopFeatureSettings: Ref<DesktopFeatureSettings>
   ensureBaseReady: (force?: boolean) => Promise<void>
   ensureBehaviorReady: (force?: boolean) => Promise<void>
@@ -49,6 +56,7 @@ export interface AdvancedSettingsDomain {
   resetAll: () => Promise<void>
   screenshotSettings: Ref<ScreenshotSettings>
   shortcutRegistered: Ref<boolean>
+  updateConnectionBehaviorSettings: (patch: Partial<ConnectionBehaviorSettingsPersistedV1>) => Promise<void>
   updateDesktopFeatureSetting: (
     key: 'alwaysOnTop' | 'fullPassThrough' | 'dynamicPassThrough' | 'autoDetectFullscreen',
     value: boolean,
@@ -79,6 +87,9 @@ type MessageApi = ReturnType<typeof useMessage>
 
 export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSettingsDomain {
   const advancedSettings = ref<AdvancedSettings>({ ...DEFAULT_ADVANCED_SETTINGS })
+  const connectionBehaviorSettings = ref<ConnectionBehaviorSettingsPersistedV1>(
+    buildDefaultConnectionBehaviorSettings(),
+  )
   const desktopFeatureSettings = ref<DesktopFeatureSettings>({
     ...DEFAULT_DESKTOP_FEATURE_SETTINGS,
   })
@@ -178,6 +189,19 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
     await applyLogLevelSetting(advancedSettings.value.logLevel)
   }
 
+  function applyConnectionBehaviorSettingsState(settings: ConnectionBehaviorSettingsPersistedV1) {
+    connectionBehaviorSettings.value = normalizeConnectionBehaviorSettings(settings)
+  }
+
+  async function loadConnectionBehaviorSettings() {
+    const result = await window.electron.connectionBehaviorSettings.load()
+    if (!result.success) {
+      throw new Error(result.message)
+    }
+
+    applyConnectionBehaviorSettingsState(result.data)
+  }
+
   function applyDesktopFeatureSettingsState(settings: DesktopFeatureSettings) {
     desktopFeatureSettings.value = {
       alwaysOnTop: Boolean(settings.alwaysOnTop),
@@ -229,6 +253,7 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
   async function ensureBehaviorReady(force = false) {
     await Promise.all([
       ensureBaseReady(force),
+      taskCache.runTask('advanced:connection-behavior', loadConnectionBehaviorSettings, force),
       taskCache.runTask('advanced:desktop', loadDesktopFeatureSettings, force),
       taskCache.runTask('advanced:screenshot', loadScreenshotSettings, force),
       taskCache.runTask('advanced:platform', loadPlatformCapabilities, force),
@@ -301,6 +326,28 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
     }
   }
 
+  async function updateConnectionBehaviorSettings(patch: Partial<ConnectionBehaviorSettingsPersistedV1>) {
+    const previousSettings = { ...connectionBehaviorSettings.value }
+    connectionBehaviorSettings.value = normalizeConnectionBehaviorSettings({
+      ...connectionBehaviorSettings.value,
+      ...patch,
+    })
+
+    try {
+      const result = await window.electron.connectionBehaviorSettings.save({
+        data: connectionBehaviorSettings.value,
+      })
+      if (!result.success) {
+        throw new Error(result.message)
+      }
+
+      applyConnectionBehaviorSettingsState(result.data)
+    } catch (error: any) {
+      connectionBehaviorSettings.value = previousSettings
+      message.error(`保存失败: ${error?.message || String(error)}`)
+    }
+  }
+
   function handleShortcutKeyDown(event: KeyboardEvent) {
     event.preventDefault()
 
@@ -355,6 +402,14 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
     persistAdvancedSettings(advancedSettings.value)
     await applyLogLevelSetting(advancedSettings.value.logLevel)
 
+    const behaviorResult = await window.electron.connectionBehaviorSettings.save({
+      data: buildDefaultConnectionBehaviorSettings(),
+    })
+    if (!behaviorResult.success) {
+      throw new Error(behaviorResult.message)
+    }
+    applyConnectionBehaviorSettingsState(behaviorResult.data)
+
     const desktopSettings = await window.electron.desktopBehavior.updatePreferences(DEFAULT_DESKTOP_FEATURE_SETTINGS)
     applyDesktopFeatureSettingsState(desktopSettings)
 
@@ -368,9 +423,11 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
   return {
     advancedSettings,
     alwaysOnTopLevelLabel,
+    applyConnectionBehaviorSettingsState,
     applyDesktopFeatureSettingsState,
     applyAdvancedSettingChange,
     checkShortcutRegistration,
+    connectionBehaviorSettings,
     desktopFeatureSettings,
     ensureBaseReady,
     ensureBehaviorReady,
@@ -388,6 +445,7 @@ export function createAdvancedSettingsDomain(message: MessageApi): AdvancedSetti
     resetAll,
     screenshotSettings,
     shortcutRegistered,
+    updateConnectionBehaviorSettings,
     updateDesktopFeatureSetting,
     updateScreenshotSettings,
   }

--- a/src/windows/settings/domains/createConnectionSettingsDomain.ts
+++ b/src/windows/settings/domains/createConnectionSettingsDomain.ts
@@ -1,29 +1,37 @@
 import { computed, inject, ref, type ComputedRef, type InjectionKey, type Ref } from 'vue'
-import { storeToRefs } from 'pinia'
 import { useMessage } from 'naive-ui'
 import { useConnectionStore } from '@/stores/connection'
-import { buildDefaultConnectionSettingsEditable } from '@/shared/connectionSettings'
+import {
+  buildDefaultConnectionSettingsEditable,
+  normalizeConnectionSettingsEditable,
+  type ConnectionSettingsEditable,
+} from '@/shared/connectionSettings'
+import { validateBridgeEndpointDraft } from '@/shared/bridgeConnectionValidation'
 
 export interface ConnectionSettingsDomain {
+  canConnect: ComputedRef<boolean>
+  canDisconnect: ComputedRef<boolean>
+  connectionStatusText: ComputedRef<string>
   ensureReady: (force?: boolean) => Promise<void>
   handleConnect: () => Promise<void>
   handleDisconnect: () => Promise<void>
+  handleExternalSettingsChanged: () => Promise<void>
   handleSaveConnectionSettings: () => Promise<void>
-  hasUnsavedConnectionSettings: Ref<boolean>
-  isConnected: Ref<boolean>
+  hasUnsavedConnectionSettings: ComputedRef<boolean>
+  isConnected: ComputedRef<boolean>
   refreshConnectionState: (force?: boolean) => Promise<void>
   resetToDefaults: () => Promise<void>
-  resourceBaseUrl: Ref<string>
-  resourcePath: Ref<string>
+  resourceBaseUrl: ComputedRef<string>
+  resourcePath: ComputedRef<string>
   resourceServerPath: Ref<string>
   resourceServerUrl: Ref<string>
   resourceAccessToken: Ref<string>
   savingConnectionSettings: Ref<boolean>
   serverUrl: Ref<string>
-  sessionId: Ref<string>
+  sessionId: ComputedRef<string>
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
   token: Ref<string>
-  userId: Ref<string>
+  userId: ComputedRef<string>
   workspaceRows: ComputedRef<Array<{ label: string; value: string }>>
 }
 
@@ -40,34 +48,102 @@ export function useConnectionSettingsDomain() {
 
 type MessageApi = ReturnType<typeof useMessage>
 
+function isSameEditableSettings(a: ConnectionSettingsEditable, b: ConnectionSettingsEditable): boolean {
+  return a.serverUrl === b.serverUrl
+    && a.token === b.token
+    && a.customResourceBaseUrl === b.customResourceBaseUrl
+    && a.customResourcePath === b.customResourcePath
+    && a.customResourceToken === b.customResourceToken
+}
+
 export function createConnectionSettingsDomain(message: MessageApi): ConnectionSettingsDomain {
   const connectionStore = useConnectionStore()
-  const {
-    customResourceBaseUrl: resourceServerUrl,
-    customResourcePath: resourceServerPath,
-    customResourceToken: resourceAccessToken,
-    hasUnsavedChanges: hasUnsavedConnectionSettings,
-    isConnected,
-    resourceBaseUrl,
-    resourcePath,
-    serverUrl,
-    sessionId,
-    token,
-    userId,
-  } = storeToRefs(connectionStore)
+
+  const serverUrl = ref('')
+  const token = ref('')
+  const resourceServerUrl = ref('')
+  const resourceServerPath = ref('')
+  const resourceAccessToken = ref('')
+  const draftInitialized = ref(false)
 
   const savingConnectionSettings = ref(false)
   const status = ref<'idle' | 'loading' | 'ready' | 'error'>('idle')
 
+  const resourceBaseUrl = computed(() => connectionStore.resourceBaseUrl)
+  const resourcePath = computed(() => connectionStore.resourcePath)
+  const isConnected = computed(() => connectionStore.isConnected)
+  const sessionId = computed(() => connectionStore.sessionId)
+  const userId = computed(() => connectionStore.userId)
+
+  const hasUnsavedConnectionSettings = computed(() => {
+    if (!draftInitialized.value) {
+      return false
+    }
+
+    return !isSameEditableSettings(collectEditableSettings(), normalizeConnectionSettingsEditable(connectionStore.persistedSettings))
+  })
+
+  const connectionStatusText = computed(() => {
+    switch (connectionStore.lifecycleStatus) {
+      case 'connecting':
+        return '正在建立连接'
+      case 'handshaking':
+        return '正在握手'
+      case 'connected':
+        return '在线'
+      case 'waiting_retry':
+        return connectionStore.nextRetryAt
+          ? `等待重试（第 ${connectionStore.reconnectAttempt} 次）`
+          : '等待重试'
+      case 'suspended':
+        return '系统挂起中'
+      case 'error':
+        return connectionStore.lastError?.message || '连接失败'
+      default:
+        return '离线'
+    }
+  })
+
+  const canConnect = computed(() => {
+    return connectionStore.lifecycleStatus !== 'connecting'
+      && connectionStore.lifecycleStatus !== 'handshaking'
+      && connectionStore.lifecycleStatus !== 'connected'
+  })
+
+  const canDisconnect = computed(() => {
+    return connectionStore.lifecycleStatus !== 'idle' || connectionStore.desiredState === 'connected'
+  })
+
   const workspaceRows = computed(() => {
     return [
-      { label: '连接状态', value: isConnected.value ? '在线' : '离线' },
+      { label: '连接状态', value: connectionStatusText.value },
+      { label: '期望状态', value: connectionStore.desiredState === 'connected' ? '保持连接' : '保持断开' },
       { label: '用户 ID', value: userId.value || '尚未分配' },
       { label: '会话 ID', value: sessionId.value || '尚未建立' },
       { label: '资源地址', value: resourceBaseUrl.value || '自动跟随' },
       { label: '资源路径', value: resourcePath.value || '/resources' },
     ]
   })
+
+  function collectEditableSettings(): ConnectionSettingsEditable {
+    return normalizeConnectionSettingsEditable({
+      serverUrl: serverUrl.value,
+      token: token.value,
+      customResourceBaseUrl: resourceServerUrl.value,
+      customResourcePath: resourceServerPath.value,
+      customResourceToken: resourceAccessToken.value,
+    })
+  }
+
+  function syncDraftFromStore() {
+    const persisted = connectionStore.persistedSettings
+    serverUrl.value = persisted.serverUrl
+    token.value = persisted.token
+    resourceServerUrl.value = persisted.customResourceBaseUrl
+    resourceServerPath.value = persisted.customResourcePath
+    resourceAccessToken.value = persisted.customResourceToken
+    draftInitialized.value = true
+  }
 
   async function ensureReady(force = false) {
     if (status.value === 'ready' && !force) {
@@ -79,18 +155,53 @@ export function createConnectionSettingsDomain(message: MessageApi): ConnectionS
     try {
       await connectionStore.ensureInitialized()
       if (force) {
-        await connectionStore.reloadPersistedSettings()
+        await Promise.all([
+          connectionStore.reloadPersistedSettings(),
+          connectionStore.refreshLifecycleSnapshot(),
+        ])
+      }
+      if (force || !hasUnsavedConnectionSettings.value) {
+        syncDraftFromStore()
       }
       status.value = 'ready'
-    } catch {
+    } catch (error) {
       status.value = 'error'
-      throw new Error('连接配置初始化失败')
+      throw error instanceof Error ? error : new Error('连接配置初始化失败')
     }
   }
 
   async function refreshConnectionState(force = false) {
     await ensureReady(force)
-    await connectionStore.checkConnection()
+    if (!force) {
+      await connectionStore.refreshLifecycleSnapshot()
+    }
+  }
+
+  async function persistDraft() {
+    const result = await window.electron.connectionSettings.save({
+      data: collectEditableSettings(),
+      expectedRevision: connectionStore.persistedRevision,
+    })
+
+    if (result.success) {
+      await connectionStore.reloadPersistedSettings()
+      syncDraftFromStore()
+      return { success: true as const }
+    }
+
+    if (result.code === 'CONFLICT_REVISION') {
+      await connectionStore.reloadPersistedSettings()
+      syncDraftFromStore()
+      return {
+        success: false as const,
+        error: '连接配置已被其他窗口更新，当前表单已刷新为最新值，请确认后重试保存',
+      }
+    }
+
+    return {
+      success: false as const,
+      error: result.message,
+    }
   }
 
   async function handleSaveConnectionSettings() {
@@ -99,9 +210,8 @@ export function createConnectionSettingsDomain(message: MessageApi): ConnectionS
     }
 
     savingConnectionSettings.value = true
-
     try {
-      const saveResult = await connectionStore.savePersistedSettings()
+      const saveResult = await persistDraft()
       if (saveResult.success) {
         message.success('连接配置已保存')
         return
@@ -114,42 +224,52 @@ export function createConnectionSettingsDomain(message: MessageApi): ConnectionS
   }
 
   async function handleConnect() {
-    const targetUrl = serverUrl.value.trim()
-    const authToken = token.value.trim()
+    const draft = collectEditableSettings()
+    const validationResult = validateBridgeEndpointDraft({
+      serverUrl: draft.serverUrl,
+      token: draft.token,
+    })
 
-    if (!authToken) {
-      message.error('请先填写认证密钥')
+    if (!validationResult.valid) {
+      message.error(validationResult.message)
       return
     }
 
-    if (authToken.length < 16) {
-      message.error('认证密钥长度至少 16 位')
+    const saveResult = await persistDraft()
+    if (!saveResult.success) {
+      message.error(`连接失败: ${saveResult.error}`)
       return
     }
 
-    serverUrl.value = targetUrl
-    token.value = authToken
-    resourceServerUrl.value = resourceServerUrl.value.trim()
-    resourceServerPath.value = resourceServerPath.value.trim()
-    resourceAccessToken.value = resourceAccessToken.value.trim()
-
-    const result = await connectionStore.connect(targetUrl, authToken)
+    const result = await window.electron.bridgeLifecycle.connect()
     if (result.success) {
-      message.success('连接成功')
+      message.success('连接请求已提交')
+      await connectionStore.refreshLifecycleSnapshot()
       return
     }
 
-    message.error(`连接失败: ${result.error}`)
+    message.error(`连接失败: ${result.message}`)
   }
 
   async function handleDisconnect() {
-    const result = await connectionStore.disconnect()
+    const result = await window.electron.bridgeLifecycle.disconnect()
     if (result.success) {
       message.success('已断开连接')
+      await connectionStore.refreshLifecycleSnapshot()
       return
     }
 
-    message.error(`断开失败: ${result.error}`)
+    message.error(`断开失败: ${result.message}`)
+  }
+
+  async function handleExternalSettingsChanged() {
+    await connectionStore.reloadPersistedSettings()
+    if (hasUnsavedConnectionSettings.value) {
+      message.warning('检测到其他窗口更新了连接配置，请先保存或放弃当前修改后再同步')
+      return
+    }
+
+    syncDraftFromStore()
   }
 
   async function resetToDefaults() {
@@ -160,18 +280,22 @@ export function createConnectionSettingsDomain(message: MessageApi): ConnectionS
     resourceServerPath.value = defaults.customResourcePath
     resourceAccessToken.value = defaults.customResourceToken
 
-    const result = await connectionStore.savePersistedSettings()
+    const result = await persistDraft()
     if (!result.success) {
       throw new Error(`连接配置重置失败: ${result.error}`)
     }
 
-    await refreshConnectionState()
+    await refreshConnectionState(true)
   }
 
   return {
+    canConnect,
+    canDisconnect,
+    connectionStatusText,
     ensureReady,
     handleConnect,
     handleDisconnect,
+    handleExternalSettingsChanged,
     handleSaveConnectionSettings,
     hasUnsavedConnectionSettings,
     isConnected,

--- a/src/windows/settings/domains/createHistorySettingsDomain.ts
+++ b/src/windows/settings/domains/createHistorySettingsDomain.ts
@@ -103,14 +103,10 @@ export function createHistorySettingsDomain(
       await connectionStore.ensureInitialized()
 
       if (force) {
-        await connectionStore.reloadPersistedSettings()
-      }
-
-      try {
-        const session = await window.electron.bridge.getSession()
-        connectionStore.applySessionState(session)
-      } catch (error) {
-        console.warn('[设置] 获取历史资源配置失败:', error)
+        await Promise.all([
+          connectionStore.reloadPersistedSettings(),
+          connectionStore.refreshLifecycleSnapshot(),
+        ])
       }
 
       historyResourceBaseUrl.value = connectionStore.resourceBaseUrl

--- a/src/windows/settings/sections/SettingsAdvancedBehaviorSection.vue
+++ b/src/windows/settings/sections/SettingsAdvancedBehaviorSection.vue
@@ -7,7 +7,75 @@
 
     <n-form label-placement="top">
       <n-form-item label="启动时自动连接">
-        <n-switch v-model:value="advancedSettings.autoConnect" @update:value="applyAdvancedSettingChange" />
+        <n-switch
+          :value="connectionBehaviorSettings.autoConnectOnAppLaunch"
+          @update:value="(value: boolean) => updateConnectionBehaviorSettings({ autoConnectOnAppLaunch: value })"
+        />
+      </n-form-item>
+      <n-form-item label="系统恢复后自动恢复连接">
+        <n-switch
+          :value="connectionBehaviorSettings.resumeDesiredConnectionOnWake"
+          @update:value="(value: boolean) => updateConnectionBehaviorSettings({ resumeDesiredConnectionOnWake: value })"
+        />
+      </n-form-item>
+      <n-form-item label="启用自动重试">
+        <n-switch
+          :value="connectionBehaviorSettings.retryEnabled"
+          @update:value="(value: boolean) => updateConnectionBehaviorSettings({ retryEnabled: value })"
+        />
+      </n-form-item>
+      <n-form-item label="重试基础延迟">
+        <n-space align="center">
+          <n-input-number
+            :value="connectionBehaviorSettings.retryBaseDelayMs"
+            :min="250"
+            :max="300000"
+            :step="250"
+            :precision="0"
+            @update:value="(value: number | null) => updateConnectionBehaviorSettings({ retryBaseDelayMs: value ?? 1000 })"
+          />
+          <span>毫秒</span>
+        </n-space>
+      </n-form-item>
+      <n-form-item label="重试最大延迟">
+        <n-space align="center">
+          <n-input-number
+            :value="connectionBehaviorSettings.retryMaxDelayMs"
+            :min="250"
+            :max="300000"
+            :step="250"
+            :precision="0"
+            @update:value="(value: number | null) => updateConnectionBehaviorSettings({ retryMaxDelayMs: value ?? 30000 })"
+          />
+          <span>毫秒</span>
+        </n-space>
+      </n-form-item>
+      <n-form-item label="最大重试次数">
+        <n-space align="center">
+          <n-input-number
+            :value="connectionBehaviorSettings.retryMaxAttempts"
+            :min="1"
+            :max="1000"
+            :precision="0"
+            clearable
+            placeholder="留空表示不限次数"
+            @update:value="(value: number | null) => updateConnectionBehaviorSettings({ retryMaxAttempts: value })"
+          />
+          <span>次</span>
+        </n-space>
+      </n-form-item>
+      <n-form-item label="握手超时">
+        <n-space align="center">
+          <n-input-number
+            :value="connectionBehaviorSettings.handshakeTimeoutMs"
+            :min="1000"
+            :max="60000"
+            :step="500"
+            :precision="0"
+            @update:value="(value: number | null) => updateConnectionBehaviorSettings({ handshakeTimeoutMs: value ?? 8000 })"
+          />
+          <span>毫秒</span>
+        </n-space>
       </n-form-item>
       <n-form-item label="启动时自动加载上次模型">
         <n-switch v-model:value="advancedSettings.autoLoadLastModel" @update:value="applyAdvancedSettingChange" />
@@ -162,6 +230,7 @@ const {
   advancedSettings,
   alwaysOnTopLevelLabel,
   applyAdvancedSettingChange,
+  connectionBehaviorSettings,
   desktopFeatureSettings,
   gameModeCapabilityLabel,
   passThroughCapabilityLabel,
@@ -169,6 +238,7 @@ const {
   platformCompatibilityNotice,
   platformDisplayName,
   screenshotSettings,
+  updateConnectionBehaviorSettings,
   updateDesktopFeatureSetting,
   updateScreenshotSettings,
 } = useAdvancedSettingsDomain()

--- a/src/windows/settings/sections/SettingsConnectionBridgeSection.vue
+++ b/src/windows/settings/sections/SettingsConnectionBridgeSection.vue
@@ -3,7 +3,7 @@
     <div class="settings-section__header">
       <h2>Bridge 连接</h2>
       <span class="status-pill" :class="isConnected ? 'status-pill--success' : 'status-pill--warning'">
-        {{ isConnected ? '已连接' : '未连接' }}
+        {{ connectionStatusText }}
       </span>
     </div>
     <p class="settings-section__desc">连接到 AstrBot Bridge 以控制 Live2D 模型和接收消息。</p>
@@ -32,10 +32,10 @@
       >
         保存连接配置
       </n-button>
-      <n-button type="primary" :disabled="isConnected || !token.trim()" @click="handleConnect">
+      <n-button type="primary" :disabled="!canConnect || !token.trim()" @click="handleConnect">
         {{ isConnected ? '已连接' : '连接服务器' }}
       </n-button>
-      <n-button :disabled="!isConnected" @click="handleDisconnect">断开连接</n-button>
+      <n-button :disabled="!canDisconnect" @click="handleDisconnect">断开连接</n-button>
     </div>
   </section>
 
@@ -68,6 +68,9 @@
 import { useConnectionSettingsDomain } from '../domains/createConnectionSettingsDomain'
 
 const {
+  canConnect,
+  canDisconnect,
+  connectionStatusText,
   handleConnect,
   handleDisconnect,
   handleSaveConnectionSettings,

--- a/tests/advancedSettings.test.ts
+++ b/tests/advancedSettings.test.ts
@@ -30,7 +30,7 @@ describe('advancedSettings', () => {
     expect(clampImageMaxSizeMb(999)).toBe(50)
   })
 
-  it('normalizes persisted settings and ignores removed wake-word fields', () => {
+  it('normalizes persisted settings and ignores removed legacy fields', () => {
     const normalized = normalizeAdvancedSettings({
       recordingShortcut: 'Ctrl+Shift+R',
       autoConnect: false,
@@ -51,7 +51,6 @@ describe('advancedSettings', () => {
 
     expect(normalized).toEqual({
       recordingShortcut: 'Ctrl+Shift+R',
-      autoConnect: false,
       autoLoadLastModel: false,
       themeFollowModel: false,
       lipSyncEnabled: false,
@@ -64,6 +63,7 @@ describe('advancedSettings', () => {
       maxRecordingSeconds: 60,
       logLevel: 'debug'
     })
+    expect(normalized).not.toHaveProperty('autoConnect')
     expect(normalized).not.toHaveProperty('wakeWordEnabled')
     expect(normalized).not.toHaveProperty('wakeKeywords')
   })
@@ -75,7 +75,6 @@ describe('advancedSettings', () => {
   it('uses defaults for newly added model behavior settings when missing', () => {
     const normalized = normalizeAdvancedSettings({
       recordingShortcut: 'Alt+R',
-      autoConnect: false,
       showBaseEventNotifications: true,
       maxRecordingSeconds: 20,
       logLevel: 'info',
@@ -127,9 +126,9 @@ describe('loadAdvancedSettings / saveAdvancedSettings', () => {
 
     const settings = loadAdvancedSettings()
     expect(settings.recordingShortcut).toBe('Ctrl+Q')
-    expect(settings.autoConnect).toBe(false)
     expect(settings.logLevel).toBe('debug')
     expect(settings.maxRecordingSeconds).toBe(25)
+    expect(settings).not.toHaveProperty('autoConnect')
     // missing fields filled from defaults
     expect(settings.bubbleStackMax).toBe(DEFAULT_ADVANCED_SETTINGS.bubbleStackMax)
   })
@@ -147,7 +146,6 @@ describe('loadAdvancedSettings / saveAdvancedSettings', () => {
   it('normalizes and persists settings to localStorage', () => {
     const saved = saveAdvancedSettings({
       recordingShortcut: 'Ctrl+W',
-      autoConnect: false,
       maxRecordingSeconds: 999,
       logLevel: 'debug',
     })

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -46,6 +46,7 @@ describe('metadata', () => {
       screenshotQuality: 'desktop_capture_quality',
       screenshotMaxWidth: 'desktop_capture_max_width',
       connectionSettingsV3: 'connection_settings_v3',
+      connectionBehaviorSettingsV1: 'connection_behavior_settings_v1',
       alwaysOnTop: 'tray_always_on_top',
       fullPassThrough: 'tray_pass_through_mode',
       dynamicPassThrough: 'desktop_dynamic_pass_through',


### PR DESCRIPTION
## 变更摘要
- 引入主进程 BridgeConnectionController，统一管理连接、自动重试、挂起恢复与状态广播
- 将连接配置与连接行为配置拆分持久化，并补齐独立 IPC 与 preload 暴露
- 重写 renderer 连接 store 与设置页连接分区，修复密钥回填与已连接状态同步问题
- 将协议客户端改为单次连接模型，移除内部重连编排

## 验证
- pnpm run typecheck
- pnpm exec vite build

## Summary by Sourcery

Introduce a centralized main-process bridge connection controller and lifecycle model, migrate connection configuration and behavior persistence, and update renderer connection logic and UI to consume the new lifecycle and retry semantics.

New Features:
- Add a main-process BridgeConnectionController that manages WebSocket connection lifecycle, retries, suspend/resume handling, and state broadcasting to renderer windows.
- Persist connection behavior settings (auto-connect, retry policy, handshake timeout) separately from connection credentials, with IPC APIs and UI controls to edit them.
- Expose a bridge lifecycle IPC surface to renderers, allowing them to observe connection state snapshots and issue connect/disconnect commands.

Bug Fixes:
- Fix desynchronization issues between stored connection settings, active session state, and UI, including proper token backfill and connected status reflection across windows.

Enhancements:
- Refactor the renderer connection store and settings domains to derive state from persisted settings plus bridge lifecycle snapshots instead of directly driving the WebSocket client.
- Replace the protocol client with a single-connection model that performs explicit handshake management, richer error classification, and no internal auto-reconnect.
- Improve connection-related status and error feedback in the main and settings windows, including retry countdown hints and lifecycle-aware status labels.

Build:
- Add a new user config key for persisted connection behavior settings.