### PR TITLE
fix: 修复实时语音未自动播放问题

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -13,11 +13,26 @@ function subscribeIpc<T extends unknown[]>(channel: string, callback: (...args: 
 }
 
 function isErrorLike(arg: any): arg is { name?: unknown; message?: unknown; stack?: unknown; code?: unknown } {
+  const code = arg && typeof arg === 'object' ? (arg as { code?: unknown }).code : undefined
   return Boolean(arg) && typeof arg === 'object' && (
     typeof arg.name === 'string'
     || typeof arg.message === 'string'
     || typeof arg.stack === 'string'
+    || typeof code === 'string'
+    || typeof code === 'number'
   )
+}
+
+function sanitizeErrorCode(code: unknown): string | number | undefined {
+  if (typeof code === 'string' || typeof code === 'number') {
+    return code
+  }
+
+  if (code != null) {
+    return String(code)
+  }
+
+  return undefined
 }
 
 function summarizeLogString(value: string): string {
@@ -48,7 +63,7 @@ function sanitizeLogValue(value: any, seen: WeakSet<object>, depth: number): any
       name: typeof value.name === 'string' ? value.name : 'UnknownError',
       message: typeof value.message === 'string' ? summarizeLogString(value.message) : String(value),
       stack: typeof value.stack === 'string' ? summarizeLogString(value.stack) : undefined,
-      code: typeof value.code === 'number' ? value.code : undefined,
+      code: sanitizeErrorCode(value.code),
     }
   }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
+const MAX_LOG_STRING_LENGTH = 512
+const MAX_LOG_DEPTH = 4
+const MAX_LOG_ARRAY_PREVIEW = 6
+
 function subscribeIpc<T extends unknown[]>(channel: string, callback: (...args: T) => void) {
   const listener = (_event: unknown, ...args: T) => callback(...args)
   ipcRenderer.on(channel, listener)
@@ -8,17 +12,101 @@ function subscribeIpc<T extends unknown[]>(channel: string, callback: (...args: 
   }
 }
 
+function isErrorLike(arg: any): arg is { name?: unknown; message?: unknown; stack?: unknown; code?: unknown } {
+  return Boolean(arg) && typeof arg === 'object' && (
+    typeof arg.name === 'string'
+    || typeof arg.message === 'string'
+    || typeof arg.stack === 'string'
+  )
+}
+
+function summarizeLogString(value: string): string {
+  if (value.startsWith('data:')) {
+    const separatorIndex = value.indexOf(',')
+    const header = separatorIndex >= 0 ? value.slice(0, separatorIndex + 1) : value
+    return `${header}<省略 ${Math.max(0, value.length - header.length)} 字符>`
+  }
+
+  if (value.length <= MAX_LOG_STRING_LENGTH) {
+    return value
+  }
+
+  return `${value.slice(0, MAX_LOG_STRING_LENGTH)}...(总长 ${value.length} 字符)`
+}
+
+function sanitizeLogValue(value: any, seen: WeakSet<object>, depth: number): any {
+  if (typeof value === 'string') {
+    return summarizeLogString(value)
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value
+  }
+
+  if (isErrorLike(value)) {
+    return {
+      name: typeof value.name === 'string' ? value.name : 'UnknownError',
+      message: typeof value.message === 'string' ? summarizeLogString(value.message) : String(value),
+      stack: typeof value.stack === 'string' ? summarizeLogString(value.stack) : undefined,
+      code: typeof value.code === 'number' ? value.code : undefined,
+    }
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  if (depth >= MAX_LOG_DEPTH) {
+    if (Array.isArray(value)) {
+      return `[Array:${value.length}]`
+    }
+    return '[Object]'
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    const preview = value
+      .slice(0, MAX_LOG_ARRAY_PREVIEW)
+      .map((item) => sanitizeLogValue(item, seen, depth + 1))
+    seen.delete(value)
+    return {
+      __type: 'array',
+      length: value.length,
+      preview,
+    }
+  }
+
+  const result: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = sanitizeLogValue(entry, seen, depth + 1)
+  }
+  seen.delete(value)
+  return result
+}
+
 function normalizeRendererLogArg(arg: any): string {
   if (typeof arg === 'string') {
-    return arg
+    return summarizeLogString(arg)
   }
 
   if (arg instanceof Error) {
-    return arg.stack || `${arg.name}: ${arg.message}`
+    return summarizeLogString(arg.stack || `${arg.name}: ${arg.message}`)
+  }
+
+  if (isErrorLike(arg)) {
+    const stack = typeof arg.stack === 'string' ? summarizeLogString(arg.stack) : ''
+    if (stack) {
+      return stack
+    }
+
+    const name = typeof arg.name === 'string' ? arg.name : 'UnknownError'
+    const message = typeof arg.message === 'string' ? summarizeLogString(arg.message) : String(arg)
+    return `${name}: ${message}`
   }
 
   try {
-    return JSON.stringify(arg)
+    return JSON.stringify(sanitizeLogValue(arg, new WeakSet<object>(), 0))
   } catch {
     return String(arg)
   }

--- a/electron/protocol/types.ts
+++ b/electron/protocol/types.ts
@@ -131,7 +131,7 @@ export interface InputMessagePayload {
 
 // 表演序列元素
 export interface PerformElement {
-  type: 'text' | 'tts' | 'motion' | 'expression' | 'image' | 'video' | 'wait'
+  type: 'text' | 'tts' | 'audio' | 'motion' | 'expression' | 'image' | 'video' | 'wait'
 
   // 文字气泡
   content?: string
@@ -168,6 +168,7 @@ export interface PerformElement {
 export interface PerformShowPayload {
   interrupt: boolean
   sequence: PerformElement[]
+  interruptible?: boolean
 }
 
 // 资源引用

--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="media-player">
     <!-- 音频播放器 -->
-    <audio ref="audioRef" @ended="handleAudioEnded" />
+    <audio
+      ref="audioRef"
+      preload="auto"
+      @abort="handleAudioAbort"
+      @ended="handleAudioEnded"
+      @error="handleAudioError"
+      @stalled="handleAudioStalled"
+    />
 
     <!-- 图片显示 -->
     <transition name="fade">
@@ -38,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 import { useConnectionStore } from '@/stores/connection'
 import { isDirectResourceUrl, resolveResourceSource, type ResourceLike } from '@/utils/resourceUrl'
 
@@ -50,6 +57,13 @@ const connectionStore = useConnectionStore()
 
 let isAudioActive = false
 let imageHideTimer: number | null = null
+let activeAudioObjectUrl: string | null = null
+let currentAudioSourceLog: Record<string, unknown> | null = null
+let isResettingAudioElement = false
+
+const AUDIO_READY_TIMEOUT_MS = 15000
+const NETWORK_STATE_LABELS = ['NETWORK_EMPTY', 'NETWORK_IDLE', 'NETWORK_LOADING', 'NETWORK_NO_SOURCE']
+const READY_STATE_LABELS = ['HAVE_NOTHING', 'HAVE_METADATA', 'HAVE_CURRENT_DATA', 'HAVE_FUTURE_DATA', 'HAVE_ENOUGH_DATA']
 
 // 定义 emit
 const emit = defineEmits<{
@@ -57,17 +71,227 @@ const emit = defineEmits<{
   audioEnd: []
 }>()
 
+function isDataUrl(url: string): boolean {
+  return url.startsWith('data:')
+}
+
+function previewUrl(url: string | null | undefined): string | null {
+  if (!url) {
+    return null
+  }
+
+  if (isDataUrl(url)) {
+    const separatorIndex = url.indexOf(',')
+    const header = separatorIndex >= 0 ? url.slice(0, separatorIndex + 1) : url
+    return `${header}<省略 ${Math.max(0, url.length - header.length)} 字符>`
+  }
+
+  if (url.length <= 240) {
+    return url
+  }
+
+  return `${url.slice(0, 240)}...(总长 ${url.length} 字符)`
+}
+
+function buildAudioSourceLog(
+  source: ResourceLike,
+  resolvedUrl: string | null = null,
+  playbackUrl: string | null = null,
+  usesObjectUrl = false,
+): Record<string, unknown> {
+  const inline = typeof source.inline === 'string' ? source.inline.trim() : ''
+  const url = typeof source.url === 'string' ? source.url.trim() : ''
+  const rid = typeof source.rid === 'string' ? source.rid.trim() : ''
+
+  let sourceKind = 'unknown'
+  if (inline) {
+    sourceKind = 'inline'
+  } else if (rid) {
+    sourceKind = 'rid'
+  } else if (url) {
+    sourceKind = 'url'
+  }
+
+  return {
+    sourceKind,
+    hasInline: Boolean(inline),
+    hasRid: Boolean(rid),
+    resolvedUrl: previewUrl(resolvedUrl),
+    playbackUrl: previewUrl(playbackUrl),
+    usesObjectUrl,
+  }
+}
+
+function formatPlaybackError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack || null,
+    }
+  }
+
+  if (error && typeof error === 'object') {
+    const errorLike = error as Record<string, unknown>
+    return {
+      name: typeof errorLike.name === 'string' ? errorLike.name : 'UnknownError',
+      message: typeof errorLike.message === 'string' ? errorLike.message : String(error),
+      code: typeof errorLike.code === 'number' ? errorLike.code : null,
+    }
+  }
+
+  return {
+    name: 'UnknownError',
+    message: String(error),
+  }
+}
+
+function describeAudioState(audioElement?: HTMLAudioElement): Record<string, unknown> | null {
+  if (!audioElement) {
+    return null
+  }
+
+  const mediaError = audioElement.error
+  return {
+    currentSrc: previewUrl(audioElement.currentSrc),
+    networkState: NETWORK_STATE_LABELS[audioElement.networkState] || audioElement.networkState,
+    readyState: READY_STATE_LABELS[audioElement.readyState] || audioElement.readyState,
+    paused: audioElement.paused,
+    ended: audioElement.ended,
+    currentTime: Number.isFinite(audioElement.currentTime) ? audioElement.currentTime : null,
+    duration: Number.isFinite(audioElement.duration) ? audioElement.duration : null,
+    errorCode: mediaError?.code ?? null,
+    errorMessage: mediaError?.message || null,
+  }
+}
+
+function revokeActiveAudioObjectUrl() {
+  if (!activeAudioObjectUrl) {
+    return
+  }
+
+  URL.revokeObjectURL(activeAudioObjectUrl)
+  activeAudioObjectUrl = null
+}
+
+function clearAudioElementSource(audioElement?: HTMLAudioElement) {
+  if (!audioElement) {
+    revokeActiveAudioObjectUrl()
+    currentAudioSourceLog = null
+    return
+  }
+
+  isResettingAudioElement = true
+  try {
+    audioElement.pause()
+    try {
+      audioElement.currentTime = 0
+    } catch {
+      // ignore invalid state when source is already unavailable
+    }
+    audioElement.removeAttribute('src')
+    audioElement.load()
+  } finally {
+    isResettingAudioElement = false
+  }
+
+  revokeActiveAudioObjectUrl()
+  currentAudioSourceLog = null
+}
+
+async function buildAudioPlaybackUrl(resolvedUrl: string): Promise<{ playbackUrl: string; usesObjectUrl: boolean }> {
+  if (!isDataUrl(resolvedUrl)) {
+    return {
+      playbackUrl: resolvedUrl,
+      usesObjectUrl: false,
+    }
+  }
+
+  const response = await fetch(resolvedUrl)
+  if (!response.ok) {
+    throw new Error(`内联音频读取失败 (${response.status})`)
+  }
+
+  const blob = await response.blob()
+  activeAudioObjectUrl = URL.createObjectURL(blob)
+  return {
+    playbackUrl: activeAudioObjectUrl,
+    usesObjectUrl: true,
+  }
+}
+
+function waitForAudioReady(audioElement: HTMLAudioElement, timeoutMs = AUDIO_READY_TIMEOUT_MS): Promise<void> {
+  if (audioElement.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+
+    const cleanup = () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+      audioElement.removeEventListener('canplay', handleCanPlay)
+      audioElement.removeEventListener('loadedmetadata', handleLoadedMetadata)
+      audioElement.removeEventListener('error', handleError)
+      audioElement.removeEventListener('abort', handleAbort)
+    }
+
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    const handleCanPlay = () => {
+      settle(resolve)
+    }
+
+    const handleLoadedMetadata = () => {
+      if (audioElement.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        settle(resolve)
+      }
+    }
+
+    const handleError = () => {
+      settle(() => reject(new Error('音频资源加载失败')))
+    }
+
+    const handleAbort = () => {
+      settle(() => reject(new Error('音频资源加载被中止')))
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      settle(() => reject(new Error(`音频资源加载超时 (${timeoutMs}ms)`)))
+    }, timeoutMs)
+
+    audioElement.addEventListener('canplay', handleCanPlay, { once: true })
+    audioElement.addEventListener('loadedmetadata', handleLoadedMetadata)
+    audioElement.addEventListener('error', handleError, { once: true })
+    audioElement.addEventListener('abort', handleAbort, { once: true })
+  })
+}
+
 /**
  * 播放音频（结构化资源对象）
  */
 async function playAudio(source: ResourceLike, volume: number = 1.0) {
-  if (!audioRef.value) return
+  const audioElement = audioRef.value
+  if (!audioElement) return
+
+  let resolvedAudioUrl: string | null = null
+  let playbackAudioUrl: string | null = null
+  let usesObjectUrl = false
 
   try {
     stopAudio()
 
     isAudioActive = true
-    const audioUrl = resolveResourceSource(
+    resolvedAudioUrl = resolveResourceSource(
       source,
       {
         resourceBaseUrl: connectionStore.resourceBaseUrl,
@@ -76,19 +300,31 @@ async function playAudio(source: ResourceLike, volume: number = 1.0) {
       }
     )
 
-    if (!audioUrl) {
+    if (!resolvedAudioUrl) {
       throw new Error('音频资源地址不可用')
     }
 
-    console.log('[媒体播放器] 播放音频:', audioUrl)
-    audioRef.value.src = audioUrl
-    audioRef.value.volume = Math.max(0, Math.min(1, volume))
-    await audioRef.value.play()
+    const preparedPlayback = await buildAudioPlaybackUrl(resolvedAudioUrl)
+    playbackAudioUrl = preparedPlayback.playbackUrl
+    usesObjectUrl = preparedPlayback.usesObjectUrl
+    currentAudioSourceLog = buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl, usesObjectUrl)
+
+    console.log('[媒体播放器] 播放音频:', currentAudioSourceLog)
+    audioElement.src = playbackAudioUrl
+    audioElement.volume = Math.max(0, Math.min(1, volume))
+    audioElement.load()
+    await waitForAudioReady(audioElement)
+    await audioElement.play()
 
     // 发射音频开始事件，传递 audio 元素用于口型同步
-    emit('audioStart', audioRef.value)
+    emit('audioStart', audioElement)
   } catch (error) {
-    console.error('[媒体播放器] 音频播放失败:', error)
+    console.error('[媒体播放器] 音频播放失败:', {
+      error: formatPlaybackError(error),
+      source: currentAudioSourceLog || buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl, usesObjectUrl),
+      element: describeAudioState(audioElement),
+    })
+    clearAudioElementSource(audioElement)
     if (isAudioActive) {
       isAudioActive = false
       emit('audioEnd')
@@ -100,13 +336,13 @@ async function playAudio(source: ResourceLike, volume: number = 1.0) {
  * 停止音频
  */
 function stopAudio() {
-  if (!audioRef.value) return
+  const audioElement = audioRef.value
+  if (!audioElement) return
 
   const shouldEmit = isAudioActive
   isAudioActive = false
 
-  audioRef.value.pause()
-  audioRef.value.currentTime = 0
+  clearAudioElementSource(audioElement)
   if (shouldEmit) {
     emit('audioEnd')
   }
@@ -198,7 +434,39 @@ function hideVideo() {
 function handleAudioEnded() {
   console.log('[媒体播放器] 音频播放结束')
   isAudioActive = false
+  revokeActiveAudioObjectUrl()
+  currentAudioSourceLog = null
   emit('audioEnd')
+}
+
+function handleAudioError() {
+  if (isResettingAudioElement) {
+    return
+  }
+  console.error('[媒体播放器] 音频元素错误事件:', {
+    source: currentAudioSourceLog,
+    element: describeAudioState(audioRef.value),
+  })
+}
+
+function handleAudioStalled() {
+  if (isResettingAudioElement) {
+    return
+  }
+  console.warn('[媒体播放器] 音频加载停滞:', {
+    source: currentAudioSourceLog,
+    element: describeAudioState(audioRef.value),
+  })
+}
+
+function handleAudioAbort() {
+  if (isResettingAudioElement) {
+    return
+  }
+  console.warn('[媒体播放器] 音频加载中止:', {
+    source: currentAudioSourceLog,
+    element: describeAudioState(audioRef.value),
+  })
 }
 
 /**
@@ -217,6 +485,10 @@ defineExpose({
   hideImage,
   playVideo,
   hideVideo
+})
+
+onBeforeUnmount(() => {
+  stopAudio()
 })
 </script>
 

--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -122,12 +122,26 @@ function buildAudioSourceLog(
   }
 }
 
+function sanitizeErrorCode(code: unknown): string | number | null {
+  if (typeof code === 'string' || typeof code === 'number') {
+    return code
+  }
+
+  if (code != null) {
+    return String(code)
+  }
+
+  return null
+}
+
 function formatPlaybackError(error: unknown): Record<string, unknown> {
   if (error instanceof Error) {
+    const errorCode = sanitizeErrorCode((error as Error & { code?: unknown }).code)
     return {
       name: error.name,
       message: error.message,
       stack: error.stack || null,
+      code: errorCode,
     }
   }
 
@@ -136,7 +150,7 @@ function formatPlaybackError(error: unknown): Record<string, unknown> {
     return {
       name: typeof errorLike.name === 'string' ? errorLike.name : 'UnknownError',
       message: typeof errorLike.message === 'string' ? errorLike.message : String(error),
-      code: typeof errorLike.code === 'number' ? errorLike.code : null,
+      code: sanitizeErrorCode(errorLike.code),
     }
   }
 

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -261,6 +261,83 @@ type AudioWaiter = {
 let audioWaiters: AudioWaiter[] = []
 const mainWindowDisposers: Unsubscribe[] = []
 
+function summarizeLogString(value: string, maxLength = 160): string {
+  if (!value) {
+    return value
+  }
+
+  if (value.startsWith('data:')) {
+    const separatorIndex = value.indexOf(',')
+    const header = separatorIndex >= 0 ? value.slice(0, separatorIndex + 1) : value
+    return `${header}<省略 ${Math.max(0, value.length - header.length)} 字符>`
+  }
+
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, maxLength)}...(总长 ${value.length} 字符)`
+}
+
+function summarizePerformElementForLog(element: PerformElement): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    type: element.type,
+  }
+
+  if (typeof element.position === 'string' && element.position) {
+    summary.position = element.position
+  }
+  if (typeof element.duration === 'number') {
+    summary.duration = element.duration
+  }
+  if (typeof element.content === 'string' && element.content) {
+    summary.content = summarizeLogString(element.content, 120)
+  }
+  if (typeof element.text === 'string' && element.text) {
+    summary.text = summarizeLogString(element.text, 120)
+  }
+  if (typeof element.url === 'string' && element.url) {
+    summary.url = summarizeLogString(element.url, 200)
+  }
+  if (typeof element.inline === 'string' && element.inline) {
+    summary.inline = summarizeLogString(element.inline, 200)
+  }
+  if (typeof element.rid === 'string' && element.rid) {
+    summary.rid = element.rid
+  }
+  if (typeof element.ttsMode === 'string' && element.ttsMode) {
+    summary.ttsMode = element.ttsMode
+  }
+  if (typeof element.volume === 'number') {
+    summary.volume = element.volume
+  }
+  if (typeof element.speed === 'number') {
+    summary.speed = element.speed
+  }
+  if (typeof element.group === 'string' && element.group) {
+    summary.group = element.group
+  }
+  if (typeof element.index === 'number') {
+    summary.index = element.index
+  }
+  if (typeof element.id === 'string' && element.id) {
+    summary.id = element.id
+  }
+
+  return summary
+}
+
+function summarizePerformPayloadForLog(payload: PerformSequence): Record<string, unknown> {
+  return {
+    interrupt: payload.interrupt,
+    interruptible: payload.interruptible ?? true,
+    sequenceLength: Array.isArray(payload.sequence) ? payload.sequence.length : 0,
+    sequencePreview: Array.isArray(payload.sequence)
+      ? payload.sequence.map((element) => summarizePerformElementForLog(element))
+      : [],
+  }
+}
+
 function settleAudioWaiter(waiter: AudioWaiter) {
   if (waiter.timeoutId !== null) {
     clearTimeout(waiter.timeoutId)
@@ -986,7 +1063,7 @@ onMounted(async () => {
   }))
 
   mainWindowDisposers.push(window.electron.bridge.onPerformShow((payload: PerformSequence) => {
-    console.log('收到表演指令:', payload)
+    console.log('收到表演指令:', summarizePerformPayloadForLog(payload))
 
     const { isFollowUp } = checkFollowUp()
 


### PR DESCRIPTION
## 目标
修复实时收到语音后未自动播放的问题，并补强播放链路的可观测性。

## 根因
实时链路收到的音频资源既可能是 `rid/url`，也可能是 `data:audio/...` 内联音频。
历史消息链路会先做资源本地化，所以播放正常；实时链路直接把 `data:` 地址交给 `<audio>`，在桌面端环境下存在不稳定和失败样本。

## 变更
- 将 `data:` 内联音频先转换为 `Blob URL` 再交给 `<audio>` 播放
- 播放前增加音频 ready 等待，补充超时、error、abort 处理
- 增强媒体播放器日志，输出资源类型、播放地址、元素状态与错误详情
- 收紧渲染日志摘要，避免整段 base64 污染日志
- 补齐主进程协议类型中的 `audio` 与 `interruptible`

## 验证
- `pnpm run typecheck`
- `pnpm exec vite build`

## Summary by Sourcery

Improve audio playback reliability and observability for real-time voice messages.

Bug Fixes:
- Ensure real-time audio messages, including data: inline audio, are converted to playable URLs and reliably auto-play in the media player.

Enhancements:
- Add audio readiness waiting, error/abort/stall handling, and detailed logging of audio source and element state in the media player.
- Sanitize and summarize large or inline data strings and complex objects in renderer and main-process logs to avoid excessive or unreadable output.
- Extend perform sequence protocol to support audio elements and an optional interruptible flag, and log condensed perform payload summaries.