### PR TITLE
feat: 支持历史消息多媒体预览

### DIFF
--- a/src/utils/historyContent.ts
+++ b/src/utils/historyContent.ts
@@ -162,7 +162,7 @@ export function buildHistoryRenderableItems(
     if (type === 'image') {
       const src = resolveHistoryImageSource(element, options)
       if (src) {
-        items.push({ type: 'image', src, alt: 'History message image' })
+        items.push({ type: 'image', src, alt: '历史消息图片' })
       }
       continue
     }

--- a/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
+++ b/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
@@ -2,7 +2,7 @@
   <teleport to="body">
     <transition name="fade">
       <div v-if="visible && src" class="history-media-viewer-overlay" @click="closeViewer">
-        <button class="close-btn" @click="closeViewer">
+        <button class="close-btn" type="button" @click.stop="closeViewer">
           <X :size="24" />
         </button>
         <div class="media-container" @click.stop>

--- a/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
+++ b/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
@@ -1,0 +1,113 @@
+<template>
+  <teleport to="body">
+    <transition name="fade">
+      <div v-if="visible" class="history-media-viewer-overlay" @click="closeViewer">
+        <button class="close-btn" @click="closeViewer">
+          <X :size="24" />
+        </button>
+        <div class="media-container" @click.stop>
+          <img v-if="type === 'image'" :src="src || ''" alt="历史消息图片放大预览" />
+          <video v-else-if="type === 'video'" :src="src || ''" controls autoplay playsinline></video>
+        </div>
+        <div class="hint-text">点击空白区域关闭</div>
+      </div>
+    </transition>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { X } from 'lucide-vue-next'
+
+const props = defineProps<{
+  visible: boolean
+  type: 'image' | 'video' | null
+  src: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [value: boolean]
+}>()
+
+function closeViewer() {
+  emit('update:visible', false)
+}
+</script>
+
+<style scoped>
+.history-media-viewer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-out;
+  backdrop-filter: blur(4px);
+}
+
+.close-btn {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  z-index: 2;
+}
+
+.close-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: scale(1.05);
+}
+
+.media-container {
+  width: 100%;
+  height: 100%;
+  padding: 60px 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  box-sizing: border-box;
+}
+
+.media-container img,
+.media-container video {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.hint-text {
+  position: absolute;
+  bottom: 24px;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 13px;
+  pointer-events: none;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
+++ b/src/windows/settings/sections/SettingsHistoryMediaViewer.vue
@@ -1,21 +1,22 @@
 <template>
   <teleport to="body">
     <transition name="fade">
-      <div v-if="visible" class="history-media-viewer-overlay" @click="closeViewer">
+      <div v-if="visible && src" class="history-media-viewer-overlay" @click="closeViewer">
         <button class="close-btn" @click="closeViewer">
           <X :size="24" />
         </button>
         <div class="media-container" @click.stop>
-          <img v-if="type === 'image'" :src="src || ''" alt="历史消息图片放大预览" />
-          <video v-else-if="type === 'video'" :src="src || ''" controls autoplay playsinline></video>
+          <img v-if="type === 'image'" :src="src" alt="历史消息图片放大预览" />
+          <video v-else-if="type === 'video'" :src="src" controls autoplay playsinline></video>
         </div>
-        <div class="hint-text">点击空白区域关闭</div>
+        <div class="hint-text">按 ESC 键或点击空白区域关闭</div>
       </div>
     </transition>
   </teleport>
 </template>
 
 <script setup lang="ts">
+import { onUnmounted, watch } from 'vue'
 import { X } from 'lucide-vue-next'
 
 const props = defineProps<{
@@ -31,6 +32,30 @@ const emit = defineEmits<{
 function closeViewer() {
   emit('update:visible', false)
 }
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.visible) {
+    closeViewer()
+  }
+}
+
+watch(
+  () => props.visible,
+  (newVal) => {
+    if (newVal) {
+      document.body.style.overflow = 'hidden'
+      window.addEventListener('keydown', handleKeyDown)
+    } else {
+      document.body.style.overflow = ''
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }
+)
+
+onUnmounted(() => {
+  document.body.style.overflow = ''
+  window.removeEventListener('keydown', handleKeyDown)
+})
 </script>
 
 <style scoped>

--- a/src/windows/settings/sections/SettingsHistoryMessagesSection.vue
+++ b/src/windows/settings/sections/SettingsHistoryMessagesSection.vue
@@ -57,7 +57,7 @@
               :class="['content-item', `content-item--${item.type}`]"
             >
               <div v-if="item.type === 'text'" class="text-content" v-html="renderMarkdown(item.text)"></div>
-              <div v-else-if="item.type === 'image'" class="image-content">
+              <div v-else-if="item.type === 'image'" class="image-content" @click.capture="openMediaViewer('image', item.src)">
                 <n-image
                   :src="item.src"
                   :preview-src="item.src"
@@ -65,6 +65,7 @@
                   object-fit="cover"
                   preview-disabled
                   :lazy="true"
+                  style="pointer-events: none"
                 />
               </div>
               <div
@@ -88,8 +89,11 @@
                   @ended="onVoiceEnded(getVoiceItemKey(msg, idx))"
                 ></audio>
               </div>
-              <div v-else-if="item.type === 'video'" class="video-content">
-                <video class="video-player" :src="item.src" controls preload="metadata" playsinline></video>
+              <div v-else-if="item.type === 'video'" class="video-content" @click="openMediaViewer('video', item.src)">
+                <div class="video-preview-wrapper">
+                  <div class="video-play-hint"><Play :size="20" /></div>
+                  <video class="video-player" :src="item.src" preload="metadata" playsinline muted></video>
+                </div>
               </div>
               <div v-else-if="item.type === 'file'" class="file-content">
                 <div class="file-header">
@@ -124,6 +128,12 @@
       @update:page-size="handlePageSizeChange"
       class="history-pagination"
     />
+
+    <SettingsHistoryMediaViewer
+      v-model:visible="mediaViewerVisible"
+      :type="mediaViewerType"
+      :src="mediaViewerSrc"
+    />
   </section>
 </template>
 
@@ -136,6 +146,7 @@ import {
   ExternalLink,
   FileText,
   Mic,
+  Play,
   Search,
   User,
 } from 'lucide-vue-next'
@@ -149,6 +160,7 @@ import {
 } from '@/utils/historyContent'
 import { configureMarked, renderBubbleMarkdown as renderMarkdownFromShared } from '@/utils/markedLatex'
 import { useHistorySettingsDomain } from '../domains/createHistorySettingsDomain'
+import SettingsHistoryMediaViewer from './SettingsHistoryMediaViewer.vue'
 
 const {
   currentPage,
@@ -185,6 +197,16 @@ const messagePreviewCache = new Map<string, HistoryRenderableItem[]>()
 const voiceRefs = new Map<string, HTMLAudioElement>()
 const voiceDurationLabels = ref<Record<string, string>>({})
 const playingVoiceKey = ref<string | null>(null)
+
+const mediaViewerVisible = ref(false)
+const mediaViewerType = ref<'image' | 'video' | null>(null)
+const mediaViewerSrc = ref<string | null>(null)
+
+function openMediaViewer(type: 'image' | 'video', src: string) {
+  mediaViewerType.value = type
+  mediaViewerSrc.value = src
+  mediaViewerVisible.value = true
+}
 
 function setVoiceRef(element: any, key: string) {
   if (element) {

--- a/src/windows/settings/sections/settings-history.scss
+++ b/src/windows/settings/sections/settings-history.scss
@@ -319,7 +319,69 @@
   display: none;
 }
 
-.video-content,
+.video-content {
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  display: inline-block;
+  line-height: 0;
+  position: relative;
+  width: fit-content;
+}
+
+.video-content:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.video-preview-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.video-play-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  pointer-events: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+  z-index: 2;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.video-content:hover .video-play-hint {
+  background: rgba(var(--color-accent-rgb), 0.8);
+  border-color: rgba(var(--color-accent-rgb), 1);
+  transform: translate(-50%, -50%) scale(1.1);
+}
+
+.video-player {
+  display: block;
+  width: 100%;
+  max-width: 280px;
+  max-height: 200px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+  pointer-events: none;
+}
+
+.video-content:hover .video-player {
+  transform: scale(1.02);
+}
+
 .file-content {
   display: flex;
   flex-direction: column;
@@ -328,13 +390,6 @@
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
-}
-
-.video-player {
-  width: 100%;
-  max-height: 200px;
-  border-radius: 6px;
-  background: rgba(0, 0, 0, 0.2);
 }
 
 .file-header {

--- a/tests/historyContent.test.ts
+++ b/tests/historyContent.test.ts
@@ -27,7 +27,7 @@ describe('historyContent', () => {
 
     expect(items).toEqual([
       { type: 'text', text: 'hello' },
-      { type: 'image', src: 'data:image/png;base64,abcd', alt: 'History message image' },
+      { type: 'image', src: 'data:image/png;base64,abcd', alt: '历史消息图片' },
     ])
   })
 
@@ -74,7 +74,7 @@ describe('historyContent', () => {
       {
         type: 'image',
         src: 'http://127.0.0.1:8090/custom-media/img_002',
-        alt: 'History message image',
+        alt: '历史消息图片',
       },
       {
         type: 'audio',


### PR DESCRIPTION
## 变更目标
为历史消息界面的图片、视频等多媒体资源提供点击放大查看与视频播放能力。

## 关键实现
- 新增历史媒体预览弹层组件，支持图片放大与视频播放
- 历史消息区图片改为点击打开预览层
- 历史消息区视频改为点击打开放大播放视图，并补充播放提示样式
- 统一历史图片文案为中文

## 验证
- npm run typecheck

## Summary by Sourcery

Add a fullscreen media viewer for historical messages and wire image/video items to open it.

New Features:
- Enable click-to-open fullscreen preview for historical images and videos in the history messages view.

Enhancements:
- Refine styling for video thumbnails in the history view with hover effects and a play hint overlay.
- Localize history image alt text and viewer copy to Chinese for consistency.