### PR TITLE
fix: 修复音频自动播放与气泡隐藏时机

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ import './ipc/bridgeLifecycle'
 // 禁用 GPU 缓存以避免权限错误（可选）
 app.commandLine.appendSwitch('disable-gpu-shader-disk-cache')
 app.commandLine.appendSwitch('disable-gpu-program-cache')
+app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
 
 // Windows 任务栏图标/分组需要 AppUserModelID 才能稳定生效
 if (process.platform === 'win32') {

--- a/electron/utils/windowThrottler.ts
+++ b/electron/utils/windowThrottler.ts
@@ -49,7 +49,7 @@ export class WindowThrottler {
     }
     
     // 2. 检查是否在忽略列表中
-    if (this.shouldIgnore(event)) {
+    if (this.shouldIgnoreEvent(event)) {
       return { shouldTrigger: false, reason: '在忽略列表中' }
     }
     
@@ -96,7 +96,7 @@ export class WindowThrottler {
   /**
    * 检查是否应该忽略
    */
-  private shouldIgnore(event: WindowEvent): boolean {
+  shouldIgnoreEvent(event: WindowEvent): boolean {
     const { processName, title } = event.window
     
     // 检查进程名（使用合并后的规则）

--- a/electron/utils/windowWatcher.ts
+++ b/electron/utils/windowWatcher.ts
@@ -176,6 +176,7 @@ export class WindowWatcherManager {
         ignore: { processNames: ['dwm.exe', 'csrss.exe', 'explorer.exe'], titleKeywords: ['Program Manager', '锁屏', 'Lock Screen'] },
         aiResponse: { mode: 'first-open', specificApps: [] },
       }
+      this.throttler = new WindowThrottler(this.config)
     }
   }
   
@@ -251,32 +252,12 @@ export class WindowWatcherManager {
    * 处理窗口事件
    */
   private handleWindowEvent(event: WindowEvent): void {
-    // 使用节流器检查是否应该触发
-    if (this.throttler) {
-      const { shouldTrigger, reason } = this.throttler.shouldTrigger(event)
-      if (!shouldTrigger) {
-        console.log(`[窗口监听] 事件被节流: ${reason}`)
-        return
-      }
-    }
-    
-    // 更新状态
+    const shouldTrackFocusContext = event.type === 'focus' && !this.throttler?.shouldIgnoreEvent(event)
+
+    // 更新状态 (应该无条件执行，否则会导致活跃窗口识别错误)
     if (event.type === 'focus') {
       this.previousWindow = this.currentWindow
       this.currentWindow = event.window
-
-      // 添加到历史记录
-      this.windowHistory.push({ window: event.window, timestamp: event.timestamp })
-
-      // 限制历史记录长度
-      if (this.windowHistory.length > 100) {
-        this.windowHistory = this.windowHistory.slice(-50)
-      }
-
-      // 应用启动检测
-      if (this.appLaunchActive) {
-        this.detectAppLaunch(event.window)
-      }
     } else if (event.type === 'blur') {
       this.previousWindow = this.currentWindow
       this.currentWindow = null
@@ -292,6 +273,26 @@ export class WindowWatcherManager {
       event.type = 'fullscreen'
     } else if (event.type === 'restore' && !event.window.isFullscreen) {
       event.type = 'windowed'
+    }
+
+    if (shouldTrackFocusContext) {
+      this.windowHistory.push({ window: event.window, timestamp: event.timestamp })
+      if (this.windowHistory.length > 100) {
+        this.windowHistory = this.windowHistory.slice(-50)
+      }
+
+      if (this.appLaunchActive) {
+        this.detectAppLaunch(event.window)
+      }
+    }
+    
+    // 使用节流器检查是否应该触发 AI 响应（或通知监听器）
+    if (this.throttler) {
+      const { shouldTrigger, reason } = this.throttler.shouldTrigger(event)
+      if (!shouldTrigger) {
+        console.log(`[窗口监听] 事件被节流: ${reason}`)
+        return
+      }
     }
     
     // 通知所有监听器

--- a/src/components/Live2D/Canvas.vue
+++ b/src/components/Live2D/Canvas.vue
@@ -547,14 +547,6 @@ defineExpose({
   getModelOverlayBounds,
   getTextureSource: () => model?.getTextureSource(),
   getTextureSources: () => model?.getTextureSources() || [],
-  startLipSync: (audioElement: HTMLAudioElement) => {
-    if (model) {
-      model.startLipSync(audioElement)
-    }
-  },
-  stopLipSync: () => {
-    model?.stopLipSync()
-  }
 })
 </script>
 

--- a/src/components/MediaPlayer.vue
+++ b/src/components/MediaPlayer.vue
@@ -57,7 +57,6 @@ const connectionStore = useConnectionStore()
 
 let isAudioActive = false
 let imageHideTimer: number | null = null
-let activeAudioObjectUrl: string | null = null
 let currentAudioSourceLog: Record<string, unknown> | null = null
 let isResettingAudioElement = false
 
@@ -67,7 +66,6 @@ const READY_STATE_LABELS = ['HAVE_NOTHING', 'HAVE_METADATA', 'HAVE_CURRENT_DATA'
 
 // 定义 emit
 const emit = defineEmits<{
-  audioStart: [audioElement: HTMLAudioElement]
   audioEnd: []
 }>()
 
@@ -97,7 +95,6 @@ function buildAudioSourceLog(
   source: ResourceLike,
   resolvedUrl: string | null = null,
   playbackUrl: string | null = null,
-  usesObjectUrl = false,
 ): Record<string, unknown> {
   const inline = typeof source.inline === 'string' ? source.inline.trim() : ''
   const url = typeof source.url === 'string' ? source.url.trim() : ''
@@ -118,7 +115,6 @@ function buildAudioSourceLog(
     hasRid: Boolean(rid),
     resolvedUrl: previewUrl(resolvedUrl),
     playbackUrl: previewUrl(playbackUrl),
-    usesObjectUrl,
   }
 }
 
@@ -179,18 +175,8 @@ function describeAudioState(audioElement?: HTMLAudioElement): Record<string, unk
   }
 }
 
-function revokeActiveAudioObjectUrl() {
-  if (!activeAudioObjectUrl) {
-    return
-  }
-
-  URL.revokeObjectURL(activeAudioObjectUrl)
-  activeAudioObjectUrl = null
-}
-
 function clearAudioElementSource(audioElement?: HTMLAudioElement) {
   if (!audioElement) {
-    revokeActiveAudioObjectUrl()
     currentAudioSourceLog = null
     return
   }
@@ -208,30 +194,7 @@ function clearAudioElementSource(audioElement?: HTMLAudioElement) {
   } finally {
     isResettingAudioElement = false
   }
-
-  revokeActiveAudioObjectUrl()
   currentAudioSourceLog = null
-}
-
-async function buildAudioPlaybackUrl(resolvedUrl: string): Promise<{ playbackUrl: string; usesObjectUrl: boolean }> {
-  if (!isDataUrl(resolvedUrl)) {
-    return {
-      playbackUrl: resolvedUrl,
-      usesObjectUrl: false,
-    }
-  }
-
-  const response = await fetch(resolvedUrl)
-  if (!response.ok) {
-    throw new Error(`内联音频读取失败 (${response.status})`)
-  }
-
-  const blob = await response.blob()
-  activeAudioObjectUrl = URL.createObjectURL(blob)
-  return {
-    playbackUrl: activeAudioObjectUrl,
-    usesObjectUrl: true,
-  }
 }
 
 function waitForAudioReady(audioElement: HTMLAudioElement, timeoutMs = AUDIO_READY_TIMEOUT_MS): Promise<void> {
@@ -299,7 +262,6 @@ async function playAudio(source: ResourceLike, volume: number = 1.0) {
 
   let resolvedAudioUrl: string | null = null
   let playbackAudioUrl: string | null = null
-  let usesObjectUrl = false
 
   try {
     stopAudio()
@@ -318,10 +280,8 @@ async function playAudio(source: ResourceLike, volume: number = 1.0) {
       throw new Error('音频资源地址不可用')
     }
 
-    const preparedPlayback = await buildAudioPlaybackUrl(resolvedAudioUrl)
-    playbackAudioUrl = preparedPlayback.playbackUrl
-    usesObjectUrl = preparedPlayback.usesObjectUrl
-    currentAudioSourceLog = buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl, usesObjectUrl)
+    playbackAudioUrl = resolvedAudioUrl
+    currentAudioSourceLog = buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl)
 
     console.log('[媒体播放器] 播放音频:', currentAudioSourceLog)
     audioElement.src = playbackAudioUrl
@@ -329,13 +289,10 @@ async function playAudio(source: ResourceLike, volume: number = 1.0) {
     audioElement.load()
     await waitForAudioReady(audioElement)
     await audioElement.play()
-
-    // 发射音频开始事件，传递 audio 元素用于口型同步
-    emit('audioStart', audioElement)
   } catch (error) {
     console.error('[媒体播放器] 音频播放失败:', {
       error: formatPlaybackError(error),
-      source: currentAudioSourceLog || buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl, usesObjectUrl),
+      source: currentAudioSourceLog || buildAudioSourceLog(source, resolvedAudioUrl, playbackAudioUrl),
       element: describeAudioState(audioElement),
     })
     clearAudioElementSource(audioElement)
@@ -448,7 +405,6 @@ function hideVideo() {
 function handleAudioEnded() {
   console.log('[媒体播放器] 音频播放结束')
   isAudioActive = false
-  revokeActiveAudioObjectUrl()
   currentAudioSourceLog = null
   emit('audioEnd')
 }

--- a/src/utils/advancedSettings.ts
+++ b/src/utils/advancedSettings.ts
@@ -20,7 +20,6 @@ export interface AdvancedSettings {
   recordingShortcut: string
   autoLoadLastModel: boolean
   themeFollowModel: boolean
-  lipSyncEnabled: boolean
   silenceDetectionEnabled: boolean
   showBaseEventNotifications: boolean
   maxRecordingSeconds: number
@@ -35,7 +34,6 @@ export const DEFAULT_ADVANCED_SETTINGS: AdvancedSettings = {
   recordingShortcut: 'Alt+R',
   autoLoadLastModel: true,
   themeFollowModel: true,
-  lipSyncEnabled: true,
   silenceDetectionEnabled: false,
   showBaseEventNotifications: true,
   maxRecordingSeconds: 30,
@@ -77,9 +75,6 @@ export function normalizeAdvancedSettings(value: unknown): AdvancedSettings {
     themeFollowModel: typeof raw.themeFollowModel === 'boolean'
       ? raw.themeFollowModel
       : DEFAULT_ADVANCED_SETTINGS.themeFollowModel,
-    lipSyncEnabled: typeof raw.lipSyncEnabled === 'boolean'
-      ? raw.lipSyncEnabled
-      : DEFAULT_ADVANCED_SETTINGS.lipSyncEnabled,
     silenceDetectionEnabled: typeof raw.silenceDetectionEnabled === 'boolean'
       ? raw.silenceDetectionEnabled
       : DEFAULT_ADVANCED_SETTINGS.silenceDetectionEnabled,

--- a/src/utils/bubbleContent.ts
+++ b/src/utils/bubbleContent.ts
@@ -86,6 +86,7 @@ export function splitPerformSequenceForBubble(
     if (!hasBubblePosition && (
       type === 'text' ||
       type === 'image' ||
+      type === 'audio' ||
       (type === 'tts' && normalizeBubbleText(ttsText))
     )) {
       const nextPosition = typeof element.position === 'string' ? element.position.trim() : ''
@@ -104,6 +105,15 @@ export function splitPerformSequenceForBubble(
       if (normalizeBubbleText(ttsText)) {
         appendBubbleTextItem(bubbleItems, ttsText)
       }
+      remainingSequence.push(element)
+      continue
+    }
+
+    if (type === 'audio') {
+      const audioText = typeof element.text === 'string' && normalizeBubbleText(element.text)
+        ? element.text
+        : '[语音消息]'
+      appendBubbleTextItem(bubbleItems, audioText)
       remainingSequence.push(element)
       continue
     }

--- a/src/utils/cubism/CubismModel.test.ts
+++ b/src/utils/cubism/CubismModel.test.ts
@@ -49,8 +49,6 @@ describe('CubismModel', () => {
     expect(typeof model.focus).toBe('function')
     expect(typeof model.motion).toBe('function')
     expect(typeof model.expression).toBe('function')
-    expect(typeof model.startLipSync).toBe('function')
-    expect(typeof model.stopLipSync).toBe('function')
     expect(typeof model.getModelInfo).toBe('function')
     expect(typeof model.getModelBounds).toBe('function')
     expect(typeof model.resize).toBe('function')
@@ -101,12 +99,6 @@ describe('CubismModel', () => {
   test('expression should not throw error', () => {
     expect(() => {
       model.expression('test_expression')
-    }).not.toThrow()
-  })
-
-  test('stopLipSync should not throw error', () => {
-    expect(() => {
-      model.stopLipSync()
     }).not.toThrow()
   })
 

--- a/src/utils/cubism/CubismModel.ts
+++ b/src/utils/cubism/CubismModel.ts
@@ -126,16 +126,6 @@ export class CubismModel {
   private isInitialized: boolean = false
   private isUpdating: boolean = false
 
-  // 口型同步相关
-  private lipSyncContext: AudioContext | null = null
-  private lipSyncAnalyser: AnalyserNode | null = null
-  private lipSyncSource: MediaElementAudioSourceNode | null = null
-  private lipSyncAudioElement: HTMLAudioElement | null = null
-  private lipSyncFrameId: number | null = null
-  private lipSyncEndedHandler: (() => void) | null = null
-  private lipSyncValue: number = 0
-  private lipSyncParamId: string = 'ParamMouthOpenY'
-
   private eyeBlinkIds: CubismIdHandle[] = []
   private lipSyncIds: CubismIdHandle[] = []
 
@@ -395,9 +385,6 @@ export class CubismModel {
       }
     }
 
-    if (this.lipSyncIds.length > 0) {
-      this.lipSyncParamId = this.lipSyncIds[0].getString().s
-    }
   }
 
   /**
@@ -912,11 +899,6 @@ export class CubismModel {
     model.addParameterValueById('ParamEyeBallX', dragX)
     model.addParameterValueById('ParamEyeBallY', dragY)
 
-    // 更新口型同步
-    if (this.lipSyncValue > 0) {
-      model.addParameterValueById(this.lipSyncParamId, this.lipSyncValue, 0.8)
-    }
-
     // 更新模型
     model.saveParameters()
     model.update()
@@ -1057,129 +1039,6 @@ export class CubismModel {
     }
 
     this.expressionManager.startMotion(expressionData.expression, false)
-  }
-
-  // ============================================================================
-  // 口型同步方法
-  // ============================================================================
-
-  /**
-   * 开始口型同步
-   */
-  startLipSync(audioElement: HTMLAudioElement): void {
-    console.log('[CubismModel] 开始口型同步')
-
-    this.stopLipSync()
-
-    try {
-      const AudioContextCtor = window.AudioContext || (window as any).webkitAudioContext
-      if (!AudioContextCtor) {
-        console.warn('[CubismModel] 当前环境不支持 AudioContext')
-        return
-      }
-
-      if (!this.lipSyncContext || this.lipSyncAudioElement !== audioElement) {
-        this.destroyLipSyncPipeline()
-        this.lipSyncContext = new AudioContextCtor()
-        this.lipSyncAnalyser = this.lipSyncContext.createAnalyser()
-        this.lipSyncAnalyser.fftSize = 256
-        this.lipSyncSource = this.lipSyncContext.createMediaElementSource(audioElement)
-        this.lipSyncSource.connect(this.lipSyncAnalyser)
-        this.lipSyncAnalyser.connect(this.lipSyncContext.destination)
-        this.lipSyncAudioElement = audioElement
-      }
-
-      if (this.lipSyncContext.state === 'suspended') {
-        void this.lipSyncContext.resume().catch(() => {})
-      }
-
-      const analyser = this.lipSyncAnalyser
-      if (!analyser) {
-        console.warn('[CubismModel] 口型同步分析器未初始化')
-        return
-      }
-      const bufferLength = analyser.frequencyBinCount
-      const dataArray = new Uint8Array(bufferLength)
-
-      // 口型同步动画循环
-      const updateLipSync = () => {
-        if (audioElement.paused || audioElement.ended) {
-          this.lipSyncValue = 0
-          return
-        }
-
-        // 获取音频频率数据
-        analyser.getByteFrequencyData(dataArray)
-
-        // 计算平均音量（0-255）
-        let sum = 0
-        for (let i = 0; i < bufferLength; i++) {
-          sum += dataArray[i]
-        }
-        const average = sum / bufferLength
-
-        // 将音量映射到口型开合度（0-1）
-        this.lipSyncValue = Math.min(average / 128, 1.0)
-
-        // 继续下一帧
-        this.lipSyncFrameId = requestAnimationFrame(updateLipSync)
-      }
-
-      updateLipSync()
-
-      this.lipSyncEndedHandler = () => {
-        this.stopLipSync()
-      }
-      audioElement.addEventListener('ended', this.lipSyncEndedHandler)
-
-    } catch (error) {
-      console.error('[CubismModel] 口型同步初始化失败:', error)
-    }
-  }
-
-  /**
-   * 停止口型同步
-   */
-  stopLipSync(): void {
-    if (this.lipSyncFrameId !== null) {
-      cancelAnimationFrame(this.lipSyncFrameId)
-      this.lipSyncFrameId = null
-    }
-
-    if (this.lipSyncAudioElement && this.lipSyncEndedHandler) {
-      this.lipSyncAudioElement.removeEventListener('ended', this.lipSyncEndedHandler)
-    }
-
-    this.lipSyncEndedHandler = null
-    this.lipSyncValue = 0
-  }
-
-  /**
-   * 销毁口型同步管线
-   */
-  private destroyLipSyncPipeline(): void {
-    this.stopLipSync()
-
-    if (this.lipSyncSource) {
-      try {
-        this.lipSyncSource.disconnect()
-      } catch {}
-      this.lipSyncSource = null
-    }
-
-    if (this.lipSyncAnalyser) {
-      try {
-        this.lipSyncAnalyser.disconnect()
-      } catch {}
-      this.lipSyncAnalyser = null
-    }
-
-    if (this.lipSyncContext) {
-      void this.lipSyncContext.close().catch(() => {})
-      this.lipSyncContext = null
-    }
-
-    this.lipSyncAudioElement = null
   }
 
   // ============================================================================
@@ -1559,9 +1418,6 @@ export class CubismModel {
 
     console.log('[CubismModel] 销毁模型')
     this.destroyed = true
-
-    this.stopLipSync()
-    this.destroyLipSyncPipeline()
 
     // 清理 WebGL 资源
     if (this.gl) {

--- a/src/windows/Main.vue
+++ b/src/windows/Main.vue
@@ -37,7 +37,6 @@
     <!-- 媒体播放器 -->
     <MediaPlayer
       ref="mediaPlayerRef"
-      @audio-start="handleAudioStart"
       @audio-end="handleAudioEnd"
     />
 
@@ -487,6 +486,8 @@ const {
   resolveModelOverlayAnchor,
   updateStackPositions,
   pushBubble,
+  holdBubble,
+  releaseBubble,
   clearAllBubbles,
   cleanup: cleanupBubbleStack,
   checkFollowUp,
@@ -644,10 +645,11 @@ async function extractAndApplyModelTheme(modelPath: string) {
 
 // Create performance queue
 const performQueue = new PerformanceQueue()
+let latestBubbleEntryId: string | null = null
 
 // Register performance queue callbacks
 performQueue.onText((content, position, _duration) => {
-  pushBubble([{ type: 'text', text: content }], position, false)
+  latestBubbleEntryId = pushBubble([{ type: 'text', text: content }], position, false)
 })
 
 performQueue.onMotion((group, index, priority) => {
@@ -662,9 +664,18 @@ performQueue.onAudio((source, volume) => {
   const mediaPlayer = mediaPlayerRef.value
   if (!mediaPlayer) return
 
+  const audioBubbleEntryId = latestBubbleEntryId
+  if (audioBubbleEntryId) {
+    holdBubble(audioBubbleEntryId)
+  }
+
   const audioEndPromise = waitForNextAudioEnd()
   void mediaPlayer.playAudio(source, volume)
-  return audioEndPromise
+  return audioEndPromise.finally(() => {
+    if (audioBubbleEntryId) {
+      releaseBubble(audioBubbleEntryId)
+    }
+  })
 })
 
 performQueue.onImage((url, _duration) => {
@@ -680,7 +691,7 @@ performQueue.onImage((url, _duration) => {
     return
   }
 
-  pushBubble([{ type: 'image', src: resolvedSrc, alt: 'AstrBot message image' }], 'center', false)
+  latestBubbleEntryId = pushBubble([{ type: 'image', src: resolvedSrc, alt: 'AstrBot message image' }], 'center', false)
 })
 
 performQueue.onVideo((url) => {
@@ -714,6 +725,7 @@ async function loadModelWithState(modelPath: string) {
 
 function interruptPerformance() {
   performQueue.interrupt()
+  latestBubbleEntryId = null
 
   clearAllBubbles()
 
@@ -976,17 +988,8 @@ watch(lastError, (error, previousError) => {
   showModelStatus(`连接错误: ${error.message}`, 'error', 4200)
 })
 
-function handleAudioStart(audioElement: HTMLAudioElement) {
-  console.log('[主窗口] 音频开始播放，启动口型同步')
-  if (!advancedSettings.value.lipSyncEnabled) {
-    return
-  }
-  live2dCanvasRef.value?.startLipSync(audioElement)
-}
-
 function handleAudioEnd() {
   console.log('[主窗口] 音频播放结束')
-  live2dCanvasRef.value?.stopLipSync()
   resolveNextAudioWaiter()
 }
 
@@ -1086,7 +1089,7 @@ onMounted(async () => {
       )
 
       if (bubbleItems.length > 0) {
-        pushBubble(bubbleItems, position, shouldInterrupt)
+        latestBubbleEntryId = pushBubble(bubbleItems, position, shouldInterrupt)
       }
 
       if (remainingSequence.length > 0) {

--- a/src/windows/composables/useBubbleStack.ts
+++ b/src/windows/composables/useBubbleStack.ts
@@ -288,6 +288,25 @@ export function useBubbleStack(options: UseBubbleStackOptions) {
     }, delay)
   }
 
+  function holdBubble(id: string) {
+    const entry = bubbleStack.value.find((item) => item.id === id)
+    if (!entry) return
+    entry.pinned = true
+    if (entry.hideTimerId !== null) {
+      clearTimeout(entry.hideTimerId)
+      entry.hideTimerId = null
+    }
+  }
+
+  function releaseBubble(id: string) {
+    const entry = bubbleStack.value.find((item) => item.id === id)
+    if (!entry) return
+    entry.pinned = false
+    if (entry.typingDone) {
+      startEntryHideTimer(entry)
+    }
+  }
+
   function removeEntry(id: string) {
     const idx = bubbleStack.value.findIndex((e) => e.id === id)
     if (idx === -1) return
@@ -349,8 +368,8 @@ export function useBubbleStack(options: UseBubbleStackOptions) {
 
   // ─── 主入口：推入新气泡 ────────────────────────────────────
 
-  function pushBubble(bubbleItems: BubbleRenderableItem[], _position: string, interrupt: boolean) {
-    if (!bubbleItems.length) return
+  function pushBubble(bubbleItems: BubbleRenderableItem[], _position: string, interrupt: boolean): string | null {
+    if (!bubbleItems.length) return null
 
     if (interrupt) {
       clearAllBubbles()
@@ -384,6 +403,8 @@ export function useBubbleStack(options: UseBubbleStackOptions) {
       updateStackPositions()
       void runEntryTypewriter(reactiveEntry)
     })
+
+    return reactiveEntry.id
   }
 
   // ─── 追踪表演时间 ──────────────────────────────────────────
@@ -411,6 +432,8 @@ export function useBubbleStack(options: UseBubbleStackOptions) {
     resolveModelOverlayAnchor,
     updateStackPositions,
     pushBubble,
+    holdBubble,
+    releaseBubble,
     clearAllBubbles,
     cleanup,
     checkFollowUp,

--- a/src/windows/settings/sections/SettingsAdvancedBehaviorSection.vue
+++ b/src/windows/settings/sections/SettingsAdvancedBehaviorSection.vue
@@ -80,12 +80,6 @@
       <n-form-item label="启动时自动加载上次模型">
         <n-switch v-model:value="advancedSettings.autoLoadLastModel" @update:value="applyAdvancedSettingChange" />
       </n-form-item>
-      <n-form-item label="音频播放时启用口型同步">
-        <n-switch v-model:value="advancedSettings.lipSyncEnabled" @update:value="applyAdvancedSettingChange" />
-        <template #feedback>
-          关闭后仍会播放音频，但不会再驱动模型口型变化。
-        </template>
-      </n-form-item>
       <n-form-item label="录音时启用静音检测">
         <n-switch v-model:value="advancedSettings.silenceDetectionEnabled" @update:value="applyAdvancedSettingChange" />
         <template #feedback>

--- a/tests/advancedSettings.test.ts
+++ b/tests/advancedSettings.test.ts
@@ -36,7 +36,6 @@ describe('advancedSettings', () => {
       autoConnect: false,
       autoLoadLastModel: false,
       themeFollowModel: false,
-      lipSyncEnabled: false,
       silenceDetectionEnabled: true,
       bubbleStackMax: 6,
       bubbleFollowUpWindowMs: 6000,
@@ -53,7 +52,6 @@ describe('advancedSettings', () => {
       recordingShortcut: 'Ctrl+Shift+R',
       autoLoadLastModel: false,
       themeFollowModel: false,
-      lipSyncEnabled: false,
       silenceDetectionEnabled: true,
       bubbleStackMax: 6,
       bubbleFollowUpWindowMs: 6000,
@@ -82,7 +80,6 @@ describe('advancedSettings', () => {
 
     expect(normalized.autoLoadLastModel).toBe(true)
     expect(normalized.themeFollowModel).toBe(true)
-    expect(normalized.lipSyncEnabled).toBe(true)
     expect(normalized.silenceDetectionEnabled).toBe(false)
     expect(normalized.bubbleStackMax).toBe(3)
     expect(normalized.bubbleFollowUpWindowMs).toBe(4000)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,11 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "types": ["node"],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@electron/*": ["electron/*"],
-      "@cubism-framework": [".generated/cubism-framework/src/index.ts"],
-      "@cubism-framework/*": [".generated/cubism-framework/src/*"]
+      "@/*": ["./src/*"],
+      "@electron/*": ["./electron/*"],
+      "@cubism-framework": ["./.generated/cubism-framework/src/index.ts"],
+      "@cubism-framework/*": ["./.generated/cubism-framework/src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "electron/**/*.ts", ".generated/cubism-framework/src/**/*.ts"],


### PR DESCRIPTION
## 变更内容
- 允许 Electron 音频无需用户手势自动播放
- 移除口型同步相关链路，避免音频播放被 WebAudio 管线影响
- 音频消息进入文字气泡展示，并保留媒体播放队列
- 音频播放未结束前锁定关联气泡，结束或超时后再恢复自动隐藏

## 验证
- pnpm run typecheck 通过
- npm run build：沙箱内 esbuild spawn EPERM；提权后超过 120 秒超时，未发现工作区污染

## Summary by Sourcery

Allow audio playback and chat bubble behavior to work reliably without WebAudio lip-sync, and tighten window event handling and configuration paths.

New Features:
- Enable Electron audio autoplay without requiring a user gesture.
- Show audio messages inside chat bubbles while preserving the media playback queue.

Bug Fixes:
- Ensure window focus tracking remains accurate while still throttling AI-triggered window events.
- Avoid issues caused by routing audio through WebAudio for lip-sync by removing the lip-sync pipeline and related integration.

Enhancements:
- Lock associated chat bubbles during audio playback and restore their auto-hide behavior after playback or timeout.
- Simplify media player audio source handling by dropping data-URL object URL conversion and cleanup.
- Expose bubble hold/release controls and propagate bubble IDs so other subsystems can control bubble lifetime.
- Make window throttling rules reusable by exposing the event-ignore helper and wiring the throttler during default config initialization.
- Clean up Live2D canvas and advanced settings by removing lip-sync-related APIs, options, and tests.

Build:
- Adjust TypeScript path mappings to use explicit project-root-relative prefixes for all aliases.

Tests:
- Update Cubism model tests to reflect the removal of lip-sync APIs.